### PR TITLE
osm_gps_map_image_get_zorder: Change return type to "gint"

### DIFF
--- a/src/osm-gps-map-image.c
+++ b/src/osm-gps-map-image.c
@@ -236,7 +236,7 @@ osm_gps_map_image_get_point(OsmGpsMapImage *object)
     return object->priv->pt;
 }
 
-const gint
+gint
 osm_gps_map_image_get_zorder(OsmGpsMapImage *object)
 {
     g_return_val_if_fail (OSM_IS_GPS_MAP_IMAGE (object), 0);

--- a/src/osm-gps-map-image.h
+++ b/src/osm-gps-map-image.h
@@ -38,7 +38,7 @@ GType osm_gps_map_image_get_type (void) G_GNUC_CONST;
 OsmGpsMapImage *osm_gps_map_image_new (void);
 void            osm_gps_map_image_draw (OsmGpsMapImage *object, GdkDrawable *drawable, GdkGC *gc, GdkRectangle *rect);
 const OsmGpsMapPoint *osm_gps_map_image_get_point(OsmGpsMapImage *object);
-const gint osm_gps_map_image_get_zorder(OsmGpsMapImage *object);
+gint osm_gps_map_image_get_zorder(OsmGpsMapImage *object);
 
 G_END_DECLS
 


### PR DESCRIPTION
... instead of "const gint".

The returned value is a scalar, not a pointer, therefore it's copied.
The "const" qualifier is unneeded and even breaks the build with older
GCC such as 4.2.
