### PR TITLE
Fix Google URIs

### DIFF
--- a/src/osm-gps-map-source.c
+++ b/src/osm-gps-map-source.c
@@ -78,11 +78,11 @@ osm_gps_map_source_get_repo_uri(OsmGpsMapSource_t source)
         case OSM_GPS_MAP_SOURCE_MAPS_FOR_FREE:
             return "http://maps-for-free.com/layer/relief/z#Z/row#Y/#Z_#X-#Y.jpg";
         case OSM_GPS_MAP_SOURCE_GOOGLE_STREET:
-            return "http://mt#R.google.com/vt/lyrs=m@146&hl=en&x=#X&s=&y=#Y&z=#Z";
+            return "http://mt#R.google.com/vt/lyrs=m&hl=en&x=#X&s=&y=#Y&z=#Z";
         case OSM_GPS_MAP_SOURCE_GOOGLE_HYBRID:
-            return "http://mt#R.google.com/vt/lyrs=h@146&hl=en&x=#X&s=&y=#Y&z=#Z";
+            return "http://mt#R.google.com/vt/lyrs=y&hl=en&x=#X&s=&y=#Y&z=#Z";
         case OSM_GPS_MAP_SOURCE_GOOGLE_SATELLITE:
-            return "http://khm#R.google.com/kh/v=89&x=#X&y=#Y&z=#Z";
+            return "http://mt#R.google.com/vt/lyrs=s&hl=en&x=#X&s=&y=#Y&z=#Z";
         case OSM_GPS_MAP_SOURCE_VIRTUAL_EARTH_STREET:
             return "http://a#R.ortho.tiles.virtualearth.net/tiles/r#W.jpeg?g=50";
         case OSM_GPS_MAP_SOURCE_VIRTUAL_EARTH_SATELLITE:


### PR DESCRIPTION
Old Google Satellite URI returns HTTP 404, old hybrid URI gave me just the labels.
