### PR TITLE
zoom and center to fit coordinates

### DIFF
--- a/src/converter.h
+++ b/src/converter.h
@@ -42,3 +42,11 @@ pixel2lon(  float zoom,
 float
 pixel2lat(  float zoom,
             int pixel_y);
+
+int
+latlon2zoom(int pix_height,
+            int pix_width,
+            float lat1,
+            float lat2,
+            float lon1,
+            float lon2);

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -2922,6 +2922,21 @@ osm_gps_map_get_bbox (OsmGpsMap *map, OsmGpsMapPoint *pt1, OsmGpsMapPoint *pt2)
 }
 
 /**
+ * osm_gps_map_zoom_fit_bbox:
+ * Zoom and center the map so that both points fit inside the window.
+ **/
+void
+osm_gps_map_zoom_fit_bbox (OsmGpsMap *map, float latitude1, float latitude2, float longitude1, float longitude2)
+{
+    GtkAllocation allocation;
+    int zoom;
+    gtk_widget_get_allocation (GTK_WIDGET (map), &allocation);
+    zoom = latlon2zoom (allocation.height, allocation.width, deg2rad(latitude1), deg2rad(latitude2), deg2rad(longitude1), deg2rad(longitude2));
+    osm_gps_map_set_center (map, (latitude1 + latitude2) / 2, (longitude1 + longitude2) / 2);
+    osm_gps_map_set_zoom (map, zoom);
+}
+
+/**
  * osm_gps_map_set_center_and_zoom:
  *
  * Since: 0.7.0

--- a/src/osm-gps-map-widget.h
+++ b/src/osm-gps-map-widget.h
@@ -85,6 +85,7 @@ gchar*          osm_gps_map_get_default_cache_directory (void);
 void            osm_gps_map_download_maps               (OsmGpsMap *map, OsmGpsMapPoint *pt1, OsmGpsMapPoint *pt2, int zoom_start, int zoom_end);
 void            osm_gps_map_download_cancel_all         (OsmGpsMap *map);
 void            osm_gps_map_get_bbox                    (OsmGpsMap *map, OsmGpsMapPoint *pt1, OsmGpsMapPoint *pt2);
+void            osm_gps_map_zoom_fit_bbox               (OsmGpsMap *map, float latitude1, float latitude2, float longitude1, float longitude2);
 void            osm_gps_map_set_center_and_zoom         (OsmGpsMap *map, float latitude, float longitude, int zoom);
 void            osm_gps_map_set_center                  (OsmGpsMap *map, float latitude, float longitude);
 int             osm_gps_map_set_zoom                    (OsmGpsMap *map, int zoom);


### PR DESCRIPTION
Hello,

I have made a function to zoom and center around four coordinates. In my opinion this is a feature that is currently missing.

The function is currently called `osm_gps_map_zoom_fit_bbox(OsmGpsMap *map, float latitude1, float latitude2, float longitude1, float longitude2);`. The 2 latitudes and longitude define a box which must fit on the screen. The calculation of the correct zoom level is placed in `converter.c`. The calculation uses a macro called `LOG2` which definition depends on the value of FLT_RADIX and is either ilogb(x) or (floor(log2(x)). A small background about (i)logb: http://www.gnu.org/software/libc/manual/html_node/Exponents-and-Logarithms.html#index-logb-2196

If there are any questions or anything else, let me know.

with kind regards,
Martijn
