### PR TITLE
make tracks and polygons clickable and make track points highlightable

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -14,7 +14,7 @@ OSMGPSMAP_LIBS =            \
 
 ## Demo Application
 if HAVE_GTHREAD
-noinst_PROGRAMS = mapviewer polygon editable_track
+noinst_PROGRAMS = mapviewer polygon editable_track clickable_track
 else
 noinst_PROGRAMS =
 endif
@@ -62,6 +62,21 @@ editable_track_CFLAGS =          \
     $(GTHREAD_CFLAGS)
 
 editable_track_LDADD =           \
+    $(OSMGPSMAP_LIBS)       \
+    $(GTHREAD_LIBS)         \
+    $(top_builddir)/src/libosmgpsmap-1.0.la
+
+clickable_track_SOURCES =         \
+    clickable_track.c
+
+clickable_track_CFLAGS =          \
+    -I$(top_srcdir)/src     \
+    $(WARN_CFLAGS)          \
+    $(DISABLE_DEPRECATED)   \
+    $(OSMGPSMAP_CFLAGS)     \
+    $(GTHREAD_CFLAGS)
+
+clickable_track_LDADD =           \
     $(OSMGPSMAP_LIBS)       \
     $(GTHREAD_LIBS)         \
     $(top_builddir)/src/libosmgpsmap-1.0.la

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -14,7 +14,7 @@ OSMGPSMAP_LIBS =            \
 
 ## Demo Application
 if HAVE_GTHREAD
-noinst_PROGRAMS = mapviewer polygon editable_track clickable_track
+noinst_PROGRAMS = mapviewer polygon editable_track clickable_track editable_clickable_track
 else
 noinst_PROGRAMS =
 endif
@@ -77,6 +77,21 @@ clickable_track_CFLAGS =          \
     $(GTHREAD_CFLAGS)
 
 clickable_track_LDADD =           \
+    $(OSMGPSMAP_LIBS)       \
+    $(GTHREAD_LIBS)         \
+    $(top_builddir)/src/libosmgpsmap-1.0.la
+
+editable_clickable_track_SOURCES =         \
+    editable_clickable_track.c
+
+editable_clickable_track_CFLAGS =          \
+    -I$(top_srcdir)/src     \
+    $(WARN_CFLAGS)          \
+    $(DISABLE_DEPRECATED)   \
+    $(OSMGPSMAP_CFLAGS)     \
+    $(GTHREAD_CFLAGS)
+
+editable_clickable_track_LDADD =           \
     $(OSMGPSMAP_LIBS)       \
     $(GTHREAD_LIBS)         \
     $(top_builddir)/src/libosmgpsmap-1.0.la

--- a/examples/clickable_track.c
+++ b/examples/clickable_track.c
@@ -1,0 +1,76 @@
+/* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
+/* vim:set et sw=4 ts=4 cino=t0,(0: */
+/*
+ * clickable_track.c
+ * Copyright (C) Martijn Goedhart 2014 <goedhart.martijn@gmail.com>
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtk/gtk.h>
+#include "osm-gps-map.h"
+#include "converter.h"
+
+void point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data);
+
+void
+point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data)
+{
+    printf("point at latitude: %.4f and longitude %.4f clicked\n", rad2deg(point->rlat), rad2deg(point->rlon));
+}
+
+int
+main (int argc, char *argv[])
+{
+    OsmGpsMap *map;
+    GtkWidget *window;
+
+    gtk_init(&argc, &argv);
+
+    window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Window");
+    g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+    map = g_object_new(OSM_TYPE_GPS_MAP, NULL);
+    gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(map));
+
+    OsmGpsMapTrack* track = osm_gps_map_track_new();
+
+    OsmGpsMapPoint* p1, *p2, *p3, *p4;
+    p1 = osm_gps_map_point_new_radians(1.25663706, -0.488692191);
+    p2 = osm_gps_map_point_new_radians(1.06465084, -0.750491578);
+    p3 = osm_gps_map_point_new_radians(1.17245321, -0.685401453);
+    p4 = osm_gps_map_point_new_radians(1.04543154, -0.105454354);
+
+    osm_gps_map_track_add_point(track, p1);
+    osm_gps_map_track_add_point(track, p2);
+    osm_gps_map_track_add_point(track, p3);
+    osm_gps_map_track_add_point(track, p4);
+
+    osm_gps_map_point_free(p1);
+    osm_gps_map_point_free(p2);
+    osm_gps_map_point_free(p3);
+    osm_gps_map_point_free(p4);
+
+    g_object_set(track, "clickable", TRUE, NULL);
+    g_signal_connect(track, "point-clicked", G_CALLBACK(point_clicked), NULL);
+
+    osm_gps_map_track_add(map, track);
+
+    gtk_widget_show(GTK_WIDGET(map));
+    gtk_widget_show(window);
+
+    gtk_main();
+
+    return 0;
+}

--- a/examples/clickable_track.c
+++ b/examples/clickable_track.c
@@ -27,6 +27,7 @@ void
 point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data)
 {
     printf("point at latitude: %.4f and longitude %.4f clicked\n", rad2deg(point->rlat), rad2deg(point->rlon));
+    osm_gps_map_track_set_highlight_point(osmgpsmaptrack, point);
 }
 
 int

--- a/examples/editable_clickable_track.c
+++ b/examples/editable_clickable_track.c
@@ -28,6 +28,7 @@ void
 point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data)
 {
     printf("point at latitude: %.4f and longitude %.4f clicked\n", rad2deg(point->rlat), rad2deg(point->rlon));
+    osm_gps_map_track_set_highlight_point(osmgpsmaptrack, point);
 }
 
 void

--- a/examples/editable_clickable_track.c
+++ b/examples/editable_clickable_track.c
@@ -1,0 +1,85 @@
+/* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
+/* vim:set et sw=4 ts=4 cino=t0,(0: */
+/*
+ * clickable_track.c
+ * Copyright (C) Martijn Goedhart 2014 <goedhart.martijn@gmail.com>
+ *
+ * This is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; version 2.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtk/gtk.h>
+#include "osm-gps-map.h"
+#include "converter.h"
+
+void point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data);
+void point_changed(OsmGpsMapTrack *osmgpsmaptrack, gpointer user_data);
+
+void
+point_clicked(OsmGpsMapTrack *osmgpsmaptrack, OsmGpsMapPoint *point, gpointer user_data)
+{
+    printf("point at latitude: %.4f and longitude %.4f clicked\n", rad2deg(point->rlat), rad2deg(point->rlon));
+}
+
+void
+point_changed(OsmGpsMapTrack *osmgpsmaptrack, gpointer user_data)
+{
+    printf("point has changed\n");
+}
+
+int
+main (int argc, char *argv[])
+{
+    OsmGpsMap *map;
+    GtkWidget *window;
+
+    gtk_init(&argc, &argv);
+
+    window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_window_set_title(GTK_WINDOW(window), "Window");
+    g_signal_connect(window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+
+    map = g_object_new(OSM_TYPE_GPS_MAP, NULL);
+    gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(map));
+
+    OsmGpsMapTrack* track = osm_gps_map_track_new();
+
+    OsmGpsMapPoint* p1, *p2, *p3, *p4;
+    p1 = osm_gps_map_point_new_radians(1.25663706, -0.488692191);
+    p2 = osm_gps_map_point_new_radians(1.06465084, -0.750491578);
+    p3 = osm_gps_map_point_new_radians(1.17245321, -0.685401453);
+    p4 = osm_gps_map_point_new_radians(1.04543154, -0.105454354);
+
+    osm_gps_map_track_add_point(track, p1);
+    osm_gps_map_track_add_point(track, p2);
+    osm_gps_map_track_add_point(track, p3);
+    osm_gps_map_track_add_point(track, p4);
+
+    osm_gps_map_point_free(p1);
+    osm_gps_map_point_free(p2);
+    osm_gps_map_point_free(p3);
+    osm_gps_map_point_free(p4);
+
+    g_object_set(track, "clickable", TRUE, NULL);
+    g_object_set(track, "editable", TRUE, NULL);
+    g_signal_connect(track, "point-clicked", G_CALLBACK(point_clicked), NULL);
+    g_signal_connect(track, "point-changed", G_CALLBACK(point_changed), NULL);
+
+    osm_gps_map_track_add(map, track);
+
+    gtk_widget_show(GTK_WIDGET(map));
+    gtk_widget_show(window);
+
+    gtk_main();
+
+    return 0;
+}

--- a/src/osm-gps-map-polygon.c
+++ b/src/osm-gps-map-polygon.c
@@ -28,16 +28,16 @@ enum
     PROP_0,
     PROP_VISIBLE,
     PROP_TRACK,
-	PROP_SHADED,
+    PROP_SHADED,
     PROP_EDITABLE
 };
 
 struct _OsmGpsMapPolygonPrivate
 {
     OsmGpsMapTrack* track;
-	gboolean visible;
+    gboolean visible;
+    gboolean shaded;
     gboolean editable;
-	gboolean shaded;
 };
 
 #define DEFAULT_R   (60000)
@@ -61,9 +61,9 @@ osm_gps_map_polygon_get_property (GObject    *object,
         case PROP_TRACK:
             g_value_set_pointer(value, priv->track);
             break;
-		case PROP_SHADED:
-			g_value_set_boolean(value, priv->shaded);
-			break;
+        case PROP_SHADED:
+            g_value_set_boolean(value, priv->shaded);
+            break;
         case PROP_EDITABLE:
             g_value_set_boolean(value, priv->editable);
             break;
@@ -89,8 +89,8 @@ osm_gps_map_polygon_set_property (GObject      *object,
             priv->track = g_value_get_pointer (value);
             break;
         case PROP_SHADED:
-			priv->shaded = g_value_get_boolean(value);
-			break;
+            priv->shaded = g_value_get_boolean(value);
+            break;
         case PROP_EDITABLE:
             priv->editable = g_value_get_boolean(value);
             break;
@@ -142,6 +142,14 @@ osm_gps_map_polygon_class_init (OsmGpsMapPolygonClass *klass)
                                                            "list of points for the polygon",
                                                            G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
+    g_object_class_install_property (object_class,
+                                     PROP_SHADED,
+                                     g_param_spec_boolean ("shaded",
+                                                           "shaded",
+                                                           "should this polygon be shaded",
+                                                           TRUE,
+                                                           G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
+
 
     g_object_class_install_property (object_class,
                                      PROP_EDITABLE,
@@ -151,27 +159,19 @@ osm_gps_map_polygon_class_init (OsmGpsMapPolygonClass *klass)
                                                            FALSE,
                                                            G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
-	g_object_class_install_property (object_class,
-                                     PROP_SHADED,
-                                     g_param_spec_boolean ("shaded",
-                                                           "shaded",
-                                                           "should this polygon be shaded",
-                                                           TRUE,
-                                                           G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
-
 }
 
 static void
 osm_gps_map_polygon_init (OsmGpsMapPolygon *self)
 {
     self->priv = G_TYPE_INSTANCE_GET_PRIVATE((self), OSM_TYPE_GPS_MAP_POLYGON, OsmGpsMapPolygonPrivate);
-	self->priv->track = osm_gps_map_track_new();
+    self->priv->track = osm_gps_map_track_new();
 }
 
 OsmGpsMapTrack*
 osm_gps_map_polygon_get_track(OsmGpsMapPolygon* poly)
 {
-	return poly->priv->track;
+     return poly->priv->track;
 }
 
 OsmGpsMapPolygon *

--- a/src/osm-gps-map-polygon.c
+++ b/src/osm-gps-map-polygon.c
@@ -29,7 +29,8 @@ enum
     PROP_VISIBLE,
     PROP_TRACK,
     PROP_SHADED,
-    PROP_EDITABLE
+    PROP_EDITABLE,
+    PROP_CLICKABLE
 };
 
 struct _OsmGpsMapPolygonPrivate
@@ -38,6 +39,7 @@ struct _OsmGpsMapPolygonPrivate
     gboolean visible;
     gboolean shaded;
     gboolean editable;
+    gboolean clickable;
 };
 
 #define DEFAULT_R   (60000)
@@ -67,6 +69,9 @@ osm_gps_map_polygon_get_property (GObject    *object,
         case PROP_EDITABLE:
             g_value_set_boolean(value, priv->editable);
             break;
+	case PROP_CLICKABLE:
+            g_value_set_boolean(value, priv->clickable);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     }
@@ -93,6 +98,9 @@ osm_gps_map_polygon_set_property (GObject      *object,
             break;
         case PROP_EDITABLE:
             priv->editable = g_value_get_boolean(value);
+            break;
+        case PROP_CLICKABLE:
+            priv->clickable = g_value_get_boolean(value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -159,6 +167,13 @@ osm_gps_map_polygon_class_init (OsmGpsMapPolygonClass *klass)
                                                            FALSE,
                                                            G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
+    g_object_class_install_property (object_class,
+                                     PROP_CLICKABLE,
+                                     g_param_spec_boolean ("clickable",
+                                                           "clickable",
+                                                           "should this polygon be clickable",
+                                                           FALSE,
+                                                           G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 }
 
 static void

--- a/src/osm-gps-map-track.c
+++ b/src/osm-gps-map-track.c
@@ -44,7 +44,8 @@ enum
     PROP_LINE_WIDTH,
     PROP_ALPHA,
     PROP_COLOR,
-    PROP_EDITABLE
+    PROP_EDITABLE,
+    PROP_CLICKABLE
 };
 
 enum
@@ -53,6 +54,7 @@ enum
     POINT_CHANGED,
     POINT_INSERTED,
     POINT_REMOVED,
+    POINT_CLICKED,
     LAST_SIGNAL
 };
 
@@ -66,6 +68,7 @@ struct _OsmGpsMapTrackPrivate
     gfloat alpha;
     GdkRGBA color;
     gboolean editable;
+    gboolean clickable;
 };
 
 #define DEFAULT_R   (0.6)
@@ -100,6 +103,9 @@ osm_gps_map_track_get_property (GObject    *object,
             break;
         case PROP_EDITABLE:
             g_value_set_boolean(value, priv->editable);
+            break;
+        case PROP_CLICKABLE:
+            g_value_set_boolean(value, priv->clickable);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -138,6 +144,9 @@ osm_gps_map_track_set_property (GObject      *object,
             } break;
         case PROP_EDITABLE:
             priv->editable = g_value_get_boolean(value);
+            break;
+        case PROP_CLICKABLE:
+            priv->clickable = g_value_get_boolean(value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -228,6 +237,14 @@ osm_gps_map_track_class_init (OsmGpsMapTrackClass *klass)
                                                            FALSE,
                                                            G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
+    g_object_class_install_property (object_class,
+                                     PROP_CLICKABLE,
+                                     g_param_spec_boolean ("clickable",
+                                                           "clickable",
+                                                           "should this track be clickable",
+                                                           FALSE,
+                                                           G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
+
 	/**
 	 * OsmGpsMapTrack::point-added:
 	 * @self: A #OsmGpsMapTrack
@@ -278,6 +295,22 @@ osm_gps_map_track_class_init (OsmGpsMapTrackClass *klass)
 	                            G_TYPE_NONE,
 	                            1,
 	                            G_TYPE_INT);
+
+    /*
+     * This signal is emitted when a point on the map is clicked/selected. The
+     * callback(s) connected to this signal will receive a pointer to the point
+     * which was clicked (hence the G_SIGNAL_TYPE_STATIC_SCOPE flag).
+     */
+    signals [POINT_CLICKED] = g_signal_new ("point-clicked",
+	                            OSM_TYPE_GPS_MAP_TRACK,
+	                            G_SIGNAL_RUN_FIRST,
+	                            0,
+	                            NULL,
+	                            NULL,
+	                            g_cclosure_marshal_VOID__POINTER,
+	                            G_TYPE_NONE,
+	                            1,
+	                            OSM_TYPE_GPS_MAP_POINT | G_SIGNAL_TYPE_STATIC_SCOPE);
 }
 
 static void

--- a/src/osm-gps-map-track.c
+++ b/src/osm-gps-map-track.c
@@ -45,7 +45,9 @@ enum
     PROP_ALPHA,
     PROP_COLOR,
     PROP_EDITABLE,
-    PROP_CLICKABLE
+    PROP_CLICKABLE,
+    PROP_HIGHLIGHT_POINT,
+    PROP_HIGHLIGHT_COLOR
 };
 
 enum
@@ -69,12 +71,26 @@ struct _OsmGpsMapTrackPrivate
     GdkRGBA color;
     gboolean editable;
     gboolean clickable;
+
+    /*
+     * Properties for highlighted points.
+     * highlight_point - Must be a pointer to a element in the list of points
+     * associated with this track or NULL.
+     * highlight_color - The color used to indicate this point as highlighted.
+     */
+    OsmGpsMapPoint *highlight_point;
+    GdkRGBA highlight_color;
 };
 
 #define DEFAULT_R   (0.6)
 #define DEFAULT_G   (0)
 #define DEFAULT_B   (0)
 #define DEFAULT_A   (0.6)
+
+#define DEFAULT_HIGHLIGHT_R   (0)
+#define DEFAULT_HIGHLIGHT_G   (0)
+#define DEFAULT_HIGHLIGHT_B   (0.6)
+#define DEFAULT_HIGHLIGHT_A   (0.6)
 
 static void
 osm_gps_map_track_get_property (GObject    *object,
@@ -106,6 +122,12 @@ osm_gps_map_track_get_property (GObject    *object,
             break;
         case PROP_CLICKABLE:
             g_value_set_boolean(value, priv->clickable);
+            break;
+        case PROP_HIGHLIGHT_POINT:
+            g_value_set_pointer(value, priv->highlight_point);
+            break;
+        case PROP_HIGHLIGHT_COLOR:
+            g_value_set_boxed(value, &priv->highlight_color);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -148,6 +170,17 @@ osm_gps_map_track_set_property (GObject      *object,
         case PROP_CLICKABLE:
             priv->clickable = g_value_get_boolean(value);
             break;
+        case PROP_HIGHLIGHT_POINT:
+            priv->highlight_point = g_value_get_pointer(value);
+            break;
+        case PROP_HIGHLIGHT_COLOR: {
+            GdkRGBA *c = g_value_get_boxed (value);
+            priv->highlight_color.red = c->red;
+            priv->highlight_color.green = c->green;
+            priv->highlight_color.blue = c->blue;
+            printf("\n%f %f %f\n", c->red, c->green, c->blue);
+            fflush(stdout);
+            } break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     }
@@ -245,6 +278,21 @@ osm_gps_map_track_class_init (OsmGpsMapTrackClass *klass)
                                                            FALSE,
                                                            G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
+    g_object_class_install_property (object_class,
+                                     PROP_HIGHLIGHT_POINT,
+                                     g_param_spec_pointer ("highlight-point",
+                                                           "highlight point",
+                                                           "point in this track that must be highlighted",
+                                                           G_PARAM_READABLE | G_PARAM_WRITABLE));
+
+    g_object_class_install_property (object_class,
+                                     PROP_HIGHLIGHT_COLOR,
+                                     g_param_spec_boxed ("highlight-color",
+                                                         "highlight color",
+                                                         "color used to mark a highlighted point",
+                                                         GDK_TYPE_COLOR,
+                                                         G_PARAM_READABLE | G_PARAM_WRITABLE));
+
 	/**
 	 * OsmGpsMapTrack::point-added:
 	 * @self: A #OsmGpsMapTrack
@@ -321,6 +369,12 @@ osm_gps_map_track_init (OsmGpsMapTrack *self)
     self->priv->color.red = DEFAULT_R;
     self->priv->color.green = DEFAULT_G;
     self->priv->color.blue = DEFAULT_B;
+
+    self->priv->highlight_color.red = DEFAULT_HIGHLIGHT_R;
+    self->priv->highlight_color.green = DEFAULT_HIGHLIGHT_G;
+    self->priv->highlight_color.blue = DEFAULT_HIGHLIGHT_B;
+
+    self->priv->highlight_point = NULL;
 }
 
 void
@@ -387,6 +441,24 @@ osm_gps_map_track_get_color (OsmGpsMapTrack *track, GdkRGBA *color)
     color->blue = track->priv->color.blue;
 }
 
+void
+osm_gps_map_track_set_highlight_color (OsmGpsMapTrack *track, GdkRGBA *color)
+{
+    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    track->priv->highlight_color.red = color->red;
+    track->priv->highlight_color.green = color->green;
+    track->priv->highlight_color.blue = color->blue;
+}
+
+void
+osm_gps_map_track_get_highlight_color (OsmGpsMapTrack *track, GdkRGBA *color)
+{
+    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    color->red = track->priv->highlight_color.red;
+    color->green = track->priv->highlight_color.green;
+    color->blue = track->priv->highlight_color.blue;
+}
+
 double
 osm_gps_map_track_get_length(OsmGpsMapTrack* track)
 {
@@ -407,6 +479,23 @@ osm_gps_map_track_get_length(OsmGpsMapTrack* track)
         points = points->next;
     }
     return ret;
+}
+
+void
+osm_gps_map_track_set_highlight_point(OsmGpsMapTrack* track, OsmGpsMapPoint *point)
+{
+    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    track->priv->highlight_point = point;
+    /* Notify ourself of the new highlight point.
+     * When a map object is listening it will update the map. */
+    g_object_notify (G_OBJECT (track), "highlight-point");
+}
+
+OsmGpsMapPoint *
+osm_gps_map_track_get_highlight_point(OsmGpsMapTrack* track)
+{
+    g_return_val_if_fail (OSM_IS_GPS_MAP_TRACK (track), NULL);
+    return track->priv->highlight_point;
 }
 
 

--- a/src/osm-gps-map-track.h
+++ b/src/osm-gps-map-track.h
@@ -80,6 +80,8 @@ void                osm_gps_map_track_add_point     (OsmGpsMapTrack *track, cons
 GSList *            osm_gps_map_track_get_points    (OsmGpsMapTrack *track);
 void                osm_gps_map_track_set_color     (OsmGpsMapTrack *track, GdkRGBA *color);
 void                osm_gps_map_track_get_color     (OsmGpsMapTrack *track, GdkRGBA *color);
+void                osm_gps_map_track_set_highlight_color (OsmGpsMapTrack *track, GdkRGBA *color);
+void                osm_gps_map_track_get_highlight_color (OsmGpsMapTrack *track, GdkRGBA *color);
 
 /**
  * osm_gps_map_track_remove_point:
@@ -104,6 +106,13 @@ OsmGpsMapPoint*     osm_gps_map_track_get_point(OsmGpsMapTrack* track, int pos);
  **/
 double              osm_gps_map_track_get_length(OsmGpsMapTrack* track);
 
+/**
+ * osm_gps_map_track_set_highlight_point:
+ * Mark the given point as highlighted on this track.
+ * @note The point must match a point in the list of points associated with the given track.
+ */
+void                osm_gps_map_track_set_highlight_point(OsmGpsMapTrack* track, OsmGpsMapPoint *point);
+OsmGpsMapPoint *    osm_gps_map_track_get_highlight_point(OsmGpsMapTrack* track);
 
 G_END_DECLS
 

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -2176,6 +2176,13 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                             OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
                             osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
                             osm_gps_map_track_insert_point(track, newpoint, ctr);
+                            /*
+                             * Also emit the point-clicked signal when a
+                             * breaker has been clicked, but after the new
+                             * point has been created.
+                             */
+                            if(path_clickable)
+                                g_signal_emit_by_name(track, "point-clicked", newpoint);
                             osm_gps_map_map_redraw(map);
                             return FALSE;
                         }
@@ -2252,6 +2259,13 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                             OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
                             osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
                             osm_gps_map_track_insert_point(track, newpoint, ctr);
+                            /*
+                             * Also emit the point-clicked signal when a
+                             * breaker has been clicked, but after the new
+                             * point has been created.
+                             */
+                            if(path_clickable)
+                                g_signal_emit_by_name(track, "point-clicked", newpoint);
                             osm_gps_map_map_redraw(map);
                             return FALSE;
                         }
@@ -2275,6 +2289,13 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                     OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
                     osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
                     osm_gps_map_track_insert_point(track, newpoint, ctr);
+                    /*
+                     * Also emit the point-clicked signal when a
+                     * breaker has been clicked, but after the new
+                     * point has been created.
+                     */
+                    if(path_clickable)
+                        g_signal_emit_by_name(track, "point-clicked", newpoint);
                     osm_gps_map_map_redraw(map);
                     return FALSE;
                 }

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -1156,18 +1156,21 @@ osm_gps_map_print_track (OsmGpsMap *map, OsmGpsMapTrack *track, cairo_t *cr)
     OsmGpsMapPrivate *priv = map->priv;
 
     GSList *pt,*points;
+    OsmGpsMapPoint *highlight_point;
     int x,y;
     int min_x = 0,min_y = 0,max_x = 0,max_y = 0;
     gfloat lw, alpha;
     int map_x0, map_y0;
-    GdkRGBA color;
+    GdkRGBA color, highlight_color;
 
     g_object_get (track,
                   "track", &points,
                   "line-width", &lw,
                   "alpha", &alpha,
+                  "highlight_point", &highlight_point,
                   NULL);
     osm_gps_map_track_get_color(track, &color);
+    osm_gps_map_track_get_highlight_color(track, &highlight_color);
 
     if (points == NULL)
         return;
@@ -1201,7 +1204,15 @@ osm_gps_map_print_track (OsmGpsMap *map, OsmGpsMapTrack *track, cairo_t *cr)
         cairo_stroke(cr);
         if(path_editable || path_clickable)
         {
-            cairo_arc (cr, x, y, DOT_RADIUS, 0.0, 2 * M_PI);
+            if(tp == highlight_point)
+            {
+                cairo_set_source_rgba (cr, highlight_color.red, highlight_color.green, highlight_color.blue, alpha);
+                cairo_arc (cr, x, y, DOT_RADIUS, 0.0, 2 * M_PI);
+                cairo_stroke(cr);
+                cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha);
+            }
+            else
+                cairo_arc (cr, x, y, DOT_RADIUS, 0.0, 2 * M_PI);
             cairo_stroke(cr);
 
             /* This draws the breaker point, do this only when the track is editable. */

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -1282,8 +1282,10 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
         return;
 
     gboolean path_editable = FALSE;
+    gboolean path_clickable = FALSE;
     gboolean poly_shaded = FALSE;
     g_object_get(poly, "editable", &path_editable, NULL);
+    g_object_get(poly, "clickable", &path_clickable, NULL);
     g_object_get(poly, "shaded", &poly_shaded, NULL);
 
     cairo_set_line_width (cr, lw);
@@ -1318,7 +1320,7 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
     else
         cairo_stroke(cr);
 
-    if(path_editable)
+    if(path_editable || path_clickable)
     {
         int last_x = 0, last_y = 0;
         for(pt = points; pt != NULL; pt = pt->next)
@@ -1331,7 +1333,8 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
             cairo_arc (cr, x, y, DOT_RADIUS, 0.0, 2 * M_PI);
             cairo_stroke(cr);
 
-            if(pt != points)
+            /* This draws the breaker point, do this only when the track is editable. */
+            if(pt != points && path_editable)
             {
                 cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha*0.75);
                 cairo_arc(cr, (last_x + x)/2.0, (last_y+y)/2.0, DOT_RADIUS, 0.0, 2*M_PI);


### PR DESCRIPTION
Points on tracks and polygons which have the clickable property set will emit a point-clicked signal when the user left-clicks on a point. When the editable property is also set a then a click is only considered as a click when the mouse pointer does not move while the left button is down. In case the mouse is moved while the left button is down it is considered as a drag-n-drop action (thus emitting a point-changed signal).

The point-select signal is also emitted after a 'breaker' has been clicked (only when editable is set).

This patch also include code to highlight a point with a (custom) highlight color (only the alpha channel is the same as for non-highlighted points). Only one point per track can be highlighted. Highlighting a point works by passing a pointer to a `OsmGpsMapPoint` (which must be in the list of track points) as value for the `highlight-point` property.

Also two examples are included to demonstrate the use of the click and highlight usage. The second example illustrate these features combined with the editable property.

If there are any question, please don't hesitate to ask.
