### PR TITLE
Add user data to each point

### DIFF
--- a/src/osm-gps-map-point.c
+++ b/src/osm-gps-map-point.c
@@ -61,6 +61,26 @@ osm_gps_map_point_new_radians(float rlat, float rlon)
     return p;
 }
 
+OsmGpsMapPoint *
+osm_gps_map_point_new_degrees_with_user_data(float lat, float lon, gpointer user_data)
+{
+    OsmGpsMapPoint *p = g_new0(OsmGpsMapPoint, 1);
+    p->rlat = deg2rad(lat);
+    p->rlon = deg2rad(lon);
+    p->user_data = user_data;
+    return p;
+}
+
+OsmGpsMapPoint *
+osm_gps_map_point_new_radians_with_user_data(float rlat, float rlon, gpointer user_data)
+{
+    OsmGpsMapPoint *p = g_new0(OsmGpsMapPoint, 1);
+    p->rlat = rlat;
+    p->rlon = rlon;
+    p->user_data = user_data;
+    return p;
+}
+
 /**
  * osm_gps_map_point_get_degrees:
  * @point: The point ( latitude and longitude in radian )
@@ -96,6 +116,18 @@ osm_gps_map_point_set_radians(OsmGpsMapPoint *point, float rlat, float rlon)
 {
     point->rlat = rlat;
     point->rlon = rlon;
+}
+
+gpointer
+osm_gps_map_point_get_user_data(OsmGpsMapPoint *point)
+{
+    return point->user_data;
+}
+
+void
+osm_gps_map_point_set_user_data(OsmGpsMapPoint *point, gpointer user_data)
+{
+    point->user_data = user_data;
 }
 
 /**

--- a/src/osm-gps-map-point.c
+++ b/src/osm-gps-map-point.c
@@ -49,6 +49,7 @@ osm_gps_map_point_new_degrees(float lat, float lon)
     OsmGpsMapPoint *p = g_new0(OsmGpsMapPoint, 1);
     p->rlat = deg2rad(lat);
     p->rlon = deg2rad(lon);
+    p->user_data = NULL;
     return p;
 }
 
@@ -58,6 +59,7 @@ osm_gps_map_point_new_radians(float rlat, float rlon)
     OsmGpsMapPoint *p = g_new0(OsmGpsMapPoint, 1);
     p->rlat = rlat;
     p->rlon = rlon;
+    p->user_data = NULL;
     return p;
 }
 

--- a/src/osm-gps-map-point.h
+++ b/src/osm-gps-map-point.h
@@ -34,16 +34,21 @@ struct _OsmGpsMapPoint
     /* radians */
     float  rlat;
     float  rlon;
+    gpointer user_data;
 };
 
 GType osm_gps_map_point_get_type (void) G_GNUC_CONST;
 
 OsmGpsMapPoint *    osm_gps_map_point_new_degrees   (float lat, float lon);
 OsmGpsMapPoint *    osm_gps_map_point_new_radians   (float rlat, float rlon);
+OsmGpsMapPoint *    osm_gps_map_point_new_degrees_with_user_data   (float lat, float lon, gpointer user_data);
+OsmGpsMapPoint *    osm_gps_map_point_new_radians_with_user_data   (float rlat, float rlon, gpointer user_data);
 void                osm_gps_map_point_get_degrees   (OsmGpsMapPoint *point, float *lat, float *lon);
 void                osm_gps_map_point_get_radians   (OsmGpsMapPoint *point, float *rlat, float *rlon);
 void                osm_gps_map_point_set_degrees   (OsmGpsMapPoint *point, float lat, float lon);
 void                osm_gps_map_point_set_radians   (OsmGpsMapPoint *point, float rlat, float rlon);
+gpointer            osm_gps_map_point_get_user_data (OsmGpsMapPoint *point);
+void                osm_gps_map_point_set_user_data (OsmGpsMapPoint *point, gpointer user_data);
 void                osm_gps_map_point_free          (OsmGpsMapPoint *point);
 OsmGpsMapPoint *    osm_gps_map_point_copy          (const OsmGpsMapPoint *point);
 


### PR DESCRIPTION
This adds a user data field to the `OsmGpsMapPoint` type. This user data field can be used to store a pointer (or some arbitrary number) and can be used to link this point to other data structures which holds information about this point.

This adds four new functions to the `OsmGpsMapPoint` type (I hope the names are self-explanatory):
osm_gps_map_point_new_degrees_with_user_data
osm_gps_map_point_new_radians_with_user_data
osm_gps_map_point_get_user_data
osm_gps_map_point_set_user_data

Please let me know what you think of this addition.
