### PR TITLE
osm-gps-map-track: Use GDK_TYPE_RGBA instead of GDK_TYPE_COLOR

### DIFF
--- a/src/osm-gps-map-track.c
+++ b/src/osm-gps-map-track.c
@@ -217,7 +217,7 @@ osm_gps_map_track_class_init (OsmGpsMapTrackClass *klass)
                                      g_param_spec_boxed ("color",
                                                          "color",
                                                          "color of the track",
-                                                         GDK_TYPE_COLOR,
+                                                         GDK_TYPE_RGBA,
                                                          G_PARAM_READABLE | G_PARAM_WRITABLE));
 
     g_object_class_install_property (object_class,


### PR DESCRIPTION
GDK_TYPE_COLOR is deprecated.

Fixes #28

Signed-off-by: Quentin Glidic <sardemff7+git@sardemff7.net>