### PR TITLE
fix type for image rotation

### DIFF
--- a/src/osm-gps-map-image.c
+++ b/src/osm-gps-map-image.c
@@ -204,7 +204,7 @@ osm_gps_map_image_class_init (OsmGpsMapImageClass *klass)
 
     g_object_class_install_property (object_class,
                                      PROP_ROTATION,
-                                     g_param_spec_int ("rotation",
+                                     g_param_spec_float ("rotation",
                                                        "rotation",
                                                        "image rotation",
                                                        -180.0, /* minimum property value */


### PR DESCRIPTION
This commit fixes warnings:
g_value_get_float: assertion `G_VALUE_HOLDS_FLOAT (value)' failed

as reported by Monte Bateman on:
https://groups.google.com/forum/#!topic/osm-gps-map/my8oW-Fw9y0