### PR TITLE
add a property that extends the HTTP user agent

### DIFF
--- a/examples/mapviewer.py
+++ b/examples/mapviewer.py
@@ -70,7 +70,7 @@ class UI(Gtk.Window):
         if 0:
             self.osm = DummyMapNoGpsPoint()
         else:
-            self.osm = osmgpsmap.Map()
+            self.osm = osmgpsmap.Map(user_agent="mapviewer.py/%s" % osmgpsmap._version)
         self.osm.layer_add(
                     osmgpsmap.MapOsd(
                         show_dpad=True,


### PR DESCRIPTION
I would like to add a property to osm-gps-map that allows application to append something to the HTTP user-agent, so that map providers (like OSM) will be able distinguish which application it is and not only see that it is using osm-gps-map.

The first part of the user-agent is still hard-coded, but setting the user-agent property for example to 'myapp/0.1' would result in the user-agent 'libosmgpsmap/1.1.0 myapp/0.1'.
