### PR TITLE
Added 'breakable' property to polygons. Also tweaked vapi file.

### DIFF
--- a/src/OsmGpsMap.vapi
+++ b/src/OsmGpsMap.vapi
@@ -9,13 +9,13 @@ namespace OsmGps {
 		[Version (since = "0.7.0")]
 		public void convert_geographic_to_screen (OsmGps.MapPoint pt, out int pixel_x, out int pixel_y);
 		[Version (since = "0.7.0")]
-		public void convert_screen_to_geographic (int pixel_x, int pixel_y, out unowned OsmGps.MapPoint pt);
+		public void convert_screen_to_geographic (int pixel_x, int pixel_y, OsmGps.MapPoint pt);
 		[Version (since = "0.7.0")]
 		public void download_cancel_all ();
 		public void download_maps (OsmGps.MapPoint pt1, OsmGps.MapPoint pt2, int zoom_start, int zoom_end);
 		[NoWrapper]
 		public virtual void draw_gps_point (Cairo.Context cr);
-		public void get_bbox (out unowned OsmGps.MapPoint pt1, out unowned OsmGps.MapPoint pt2);
+		public void get_bbox (OsmGps.MapPoint pt1, OsmGps.MapPoint pt2);
 		public static string get_default_cache_directory ();
 		[Version (since = "0.7.0")]
 		public OsmGps.MapPoint get_event_location (Gdk.EventButton event);
@@ -207,6 +207,8 @@ namespace OsmGps {
 		public void* track { get; set construct; }
 		[NoAccessorMethod]
 		public bool visible { get; set construct; }
+		[NoAccessorMethod]
+		public bool breakable { get; set construct; }
 	}
 	[CCode (cheader_filename = "osm-gps-map.h", type_id = "osm_gps_map_track_get_type ()")]
 	public class MapTrack : GLib.Object {
@@ -216,7 +218,7 @@ namespace OsmGps {
 		public void add_point (OsmGps.MapPoint point);
 		public void get_color (Gdk.RGBA color);
 		public double get_length ();
-		public OsmGps.MapPoint get_point (int pos);
+		public unowned OsmGps.MapPoint get_point (int pos);
 		[Version (since = "0.7.0")]
 		public unowned GLib.SList<OsmGps.MapPoint> get_points ();
 		public void insert_point (OsmGps.MapPoint np, int pos);

--- a/src/osm-gps-map-polygon.c
+++ b/src/osm-gps-map-polygon.c
@@ -30,7 +30,8 @@ enum
     PROP_TRACK,
 	PROP_SHADED,
     PROP_EDITABLE,
-    PROP_SHADE_ALPHA
+    PROP_SHADE_ALPHA,
+    PROP_BREAKABLE
 };
 
 struct _OsmGpsMapPolygonPrivate
@@ -40,6 +41,7 @@ struct _OsmGpsMapPolygonPrivate
     gboolean editable;
 	gboolean shaded;
     gfloat shade_alpha;
+    gboolean breakable;
 };
 
 #define DEFAULT_R   (60000)
@@ -72,6 +74,9 @@ osm_gps_map_polygon_get_property (GObject    *object,
         case PROP_SHADE_ALPHA:
             g_value_set_float(value, priv->shade_alpha);
             break;
+        case PROP_BREAKABLE:
+            g_value_set_boolean(value, priv->breakable);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
     }
@@ -101,6 +106,9 @@ osm_gps_map_polygon_set_property (GObject      *object,
             break;
         case PROP_SHADE_ALPHA:
             priv->shade_alpha = g_value_get_float(value);
+            break;
+        case PROP_BREAKABLE:
+            priv->breakable = g_value_get_boolean(value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -175,6 +183,14 @@ osm_gps_map_polygon_class_init (OsmGpsMapPolygonClass *klass)
                                                         0.0,
                                                         1.0,
                                                         0.5,
+                                                        G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
+
+    g_object_class_install_property(object_class,
+                                    PROP_BREAKABLE,
+                                    g_param_spec_boolean("breakable",
+                                                        "breakable",
+                                                        "can polygons have points inserted using breakers",
+                                                        TRUE,
                                                         G_PARAM_READABLE | G_PARAM_WRITABLE | G_PARAM_CONSTRUCT));
 
 }

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -1275,9 +1275,11 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
 
     gboolean path_editable = FALSE;
     gboolean poly_shaded = FALSE;
+    gboolean breakable = TRUE;
     g_object_get(poly, "editable", &path_editable, NULL);
     g_object_get(poly, "shaded", &poly_shaded, NULL);
     g_object_get(poly, "shade_alpha", &shade_alpha, NULL);
+    g_object_get(poly, "breakable", &breakable, NULL);
 
     cairo_set_line_width (cr, lw);
     cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha);
@@ -1321,7 +1323,7 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
             cairo_arc (cr, x, y, DOT_RADIUS, 0.0, 2 * M_PI);
             cairo_stroke(cr);
 
-            if(pt != points)
+            if((pt != points) && (breakable))
             {
                 cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha*0.75);
                 cairo_arc(cr, (last_x + x)/2.0, (last_y+y)/2.0, DOT_RADIUS, 0.0, 2*M_PI);
@@ -1332,9 +1334,12 @@ osm_gps_map_print_polygon (OsmGpsMap *map, OsmGpsMapPolygon *poly, cairo_t *cr)
         }
 
         x = first_x; y = first_y;
-        cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha*0.75);
-        cairo_arc(cr, (last_x + x)/2.0, (last_y+y)/2.0, DOT_RADIUS, 0.0, 2*M_PI);
-        cairo_stroke(cr);
+        if(breakable)
+        {
+            cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha*0.75);
+            cairo_arc(cr, (last_x + x)/2.0, (last_y+y)/2.0, DOT_RADIUS, 0.0, 2*M_PI);
+            cairo_stroke(cr);
+        }
         cairo_set_source_rgba (cr, color.red, color.green, color.blue, alpha);
     }
 
@@ -2227,8 +2232,10 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
         {
             OsmGpsMapPolygon* poly = polys->data;
             gboolean path_editable = FALSE;
+            gboolean breakable = TRUE;
             OsmGpsMapTrack* track = osm_gps_map_polygon_get_track(poly);
             g_object_get(poly, "editable", &path_editable, NULL);
+            g_object_get(poly, "breakable", &breakable, NULL);
             if(path_editable)
             {
                 GSList* points = osm_gps_map_track_get_points(track);
@@ -2255,7 +2262,7 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                     }
 
                     //add a new point if a 'breaker' has been clicked
-                    if(ctr != 0)
+                    if((ctr != 0) && (breakable))
                     {
                         int ptx = (last_x+cx)/2.0;
                         int pty = (last_y+cy)/2.0;


### PR DESCRIPTION
This is an idea that was discussed in another pull request. I've recently had a need to create polygons that can have points moved but not added or inserted. To do this, I've added a 'breakable' property to polygons. If set to true, editable polygons can have points inserted by the user clicking on 'breakers'. If false, an editable polygon can have its points dragged but no new points can be created. 