### PR TITLE
OSM forward all http resquest to https.

### DIFF
--- a/src/osm-gps-map-source.c
+++ b/src/osm-gps-map-source.c
@@ -123,7 +123,7 @@ osm_gps_map_source_get_repo_uri(OsmGpsMapSource_t source)
             // Appears to be shut down
             return NULL;
         case OSM_GPS_MAP_SOURCE_MAPS_FOR_FREE:
-            return "http://maps-for-free.com/layer/relief/z#Z/row#Y/#Z_#X-#Y.jpg";
+            return "https://maps-for-free.com/layer/relief/z#Z/row#Y/#Z_#X-#Y.jpg";
         case OSM_GPS_MAP_SOURCE_GOOGLE_STREET:
             return "http://mt#R.google.com/vt/lyrs=m&hl=en&x=#X&s=&y=#Y&z=#Z";
         case OSM_GPS_MAP_SOURCE_GOOGLE_HYBRID:

--- a/src/private.h
+++ b/src/private.h
@@ -34,7 +34,7 @@
 #define MAX_TILE_ZOOM_OFFSET 10
 #define MIN_TILE_ZOOM_OFFSET 0
 
-#define OSM_REPO_URI        "http://tile.openstreetmap.org/#Z/#X/#Y.png"
+#define OSM_REPO_URI        "https://tile.openstreetmap.org/#Z/#X/#Y.png"
 #define OSM_MIN_ZOOM        1
 #define OSM_MAX_ZOOM        19
 #define OSM_IMAGE_FORMAT    "png"


### PR DESCRIPTION
After asking the OSM support, I was told OSM forward all http request to
https when we use .org url.
So it should work in all cases.

Trying for all urls, I saw that maps-for-free.com does the same thing.

This has an energy cost, so it would be good for the planet to change
http to https.