### PR TITLE
Update install instructions for Debian distros

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,11 +103,11 @@
 
     <h2>Install Instructions</h2>
     <p>osm-gps-map should be packaged by your distibution. On Debian, Ubuntu or
-      similar, you can install using the following;
-<pre>sudo apt-get install libosmgpsmap-dev python-osmgpsmap</pre></p>
+    similar, you can install the GTK+ library and its Python bindings like this:
+<pre>sudo apt-get install libosmgpsmap-1.0-1 gir1.2-osmgpsmap-1.0</pre></p>
 
     <h3>Installing From Source</h3>
-    <p>To build from source on Linux you will need to install the following dependencies;
+    <p>To build from source on Linux you will need to install the following dependencies:
     <ul>
         <li>libsoup-2.4</li>
         <li>gtk+-3.0</li>
@@ -115,7 +115,7 @@
         <li>gobject-introspection</li>
     </ul></p>
 
-    <p>Once the dependencies have been installed you can build osm-gps-map. On Linux perform the following;
+    <p>Once the dependencies have been installed you can build osm-gps-map. On Linux perform the following:
 <pre>./configure; make; make install #C library
 cd python; ./configure; make; make install #Python bindings</pre>
     </p>

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
 	<title>nzjrs/osm-gps-map @ GitHub</title>
-	
+
 	<style type="text/css">
 		body {
   		margin-top: 1.0em;
   		background-color: #333333;
-		  font-family: "helvetica"; 
+		  font-family: "helvetica";
   		color: #ffffff;
     }
     #container {
@@ -43,12 +43,12 @@
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 
-</script>	
+</script>
 </head>
 
 <body>
   <a href="http://github.com/nzjrs/osm-gps-map"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
-  
+
   <div id="container">
 
     <div class="download">
@@ -57,15 +57,15 @@
       <a href="http://github.com/nzjrs/osm-gps-map/tarball/master">
         <img border="0" width="90" src="http://github.com/images/modules/download/tar.png"></a>
     </div>
-      
-    <h1><a href="http://github.com/nzjrs/osm-gps-map">osm-gps-map</a> 
+
+    <h1><a href="http://github.com/nzjrs/osm-gps-map">osm-gps-map</a>
       <span class="small">by <a href="http://github.com/nzjrs">nzjrs</a></small></h1>
 
     <div class="description">
-      A Gtk+ Widget for Displaying OpenStreetMap tiles. 
+      A Gtk+ Widget for Displaying OpenStreetMap tiles.
     </div>
 
-    <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display. 
+    <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
     Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ and Maemo applications.</p>
     <p><img src="screenshot.png"/><br/><img src="screenshot-osd.png"/></p>
     <p>Currently supports a number of different mapping sources<br/>
@@ -103,7 +103,7 @@
 
     <h2>Install Instructions</h2>
     <p>osm-gps-map should be packaged by your distibution. On Debian, Ubuntu or
-similar, you can install using the following;
+      similar, you can install using the following;
 <pre>sudo apt-get install libosmgpsmap-dev python-osmgpsmap</pre></p>
 
     <h3>Installing From Source</h3>
@@ -166,7 +166,7 @@ cd python; ./configure; make; make install #Python bindings</pre>
     <div class="footer">
       get the source code on GitHub : <a href="http://github.com/nzjrs/osm-gps-map">nzjrs/osm-gps-map</a>
     </div>
-    
+
   </div>
 </body>
 </html>


### PR DESCRIPTION
The package names have seemingly changed for Debian and derived distributions. This updates the website accordingly.

I've made a separate commit for the whitespace changes my (aka "any modern") editor introduced. I hope that's fine.