### PR TITLE
Fix "Unknown namespace for symbol" warnings

### DIFF
--- a/src/osm-gps-map-image.c
+++ b/src/osm-gps-map-image.c
@@ -232,7 +232,7 @@ osm_gps_map_image_draw (OsmGpsMapImage *object, cairo_t *cr, GdkRectangle *rect)
     int xoffset, yoffset;
     gdouble x,y;
 
-    g_return_if_fail (OSM_IS_GPS_MAP_IMAGE (object));
+    g_return_if_fail (OSM_GPS_MAP_IS_IMAGE (object));
     priv = OSM_GPS_MAP_IMAGE(object)->priv;
 
     xoffset =  priv->xalign * priv->w;
@@ -258,14 +258,14 @@ osm_gps_map_image_draw (OsmGpsMapImage *object, cairo_t *cr, GdkRectangle *rect)
 const OsmGpsMapPoint *
 osm_gps_map_image_get_point(OsmGpsMapImage *object)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP_IMAGE (object), NULL);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_IMAGE (object), NULL);
     return object->priv->pt;
 }
 
 gint
 osm_gps_map_image_get_zorder(OsmGpsMapImage *object)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP_IMAGE (object), 0);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_IMAGE (object), 0);
     return object->priv->zorder;
 }
 

--- a/src/osm-gps-map-image.h
+++ b/src/osm-gps-map-image.h
@@ -31,8 +31,8 @@ G_BEGIN_DECLS
 #define OSM_TYPE_GPS_MAP_IMAGE              osm_gps_map_image_get_type()
 #define OSM_GPS_MAP_IMAGE(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSM_TYPE_GPS_MAP_IMAGE, OsmGpsMapImage))
 #define OSM_GPS_MAP_IMAGE_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), OSM_TYPE_GPS_MAP_IMAGE, OsmGpsMapImageClass))
-#define OSM_IS_GPS_MAP_IMAGE(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_IMAGE))
-#define OSM_IS_GPS_MAP_IMAGE_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_IMAGE))
+#define OSM_GPS_MAP_IS_IMAGE(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_IMAGE))
+#define OSM_GPS_MAP_IS_IMAGE_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_IMAGE))
 #define OSM_GPS_MAP_IMAGE_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), OSM_TYPE_GPS_MAP_IMAGE, OsmGpsMapImageClass))
 
 typedef struct _OsmGpsMapImage OsmGpsMapImage;

--- a/src/osm-gps-map-osd.c
+++ b/src/osm-gps-map-osd.c
@@ -484,7 +484,7 @@ osm_gps_map_osd_render (OsmGpsMapLayer *osd,
     OsmGpsMapOsd *self;
     OsmGpsMapOsdPrivate *priv;
 
-    g_return_if_fail(OSM_IS_GPS_MAP_OSD(osd));
+    g_return_if_fail(OSM_GPS_MAP_IS_OSD(osd));
 
     self = OSM_GPS_MAP_OSD(osd);
     priv = self->priv;
@@ -511,7 +511,7 @@ osm_gps_map_osd_draw (OsmGpsMapLayer *osd,
     OsmGpsMapOsdPrivate *priv;
     GtkAllocation allocation;
 
-    g_return_if_fail(OSM_IS_GPS_MAP_OSD(osd));
+    g_return_if_fail(OSM_GPS_MAP_IS_OSD(osd));
 
     self = OSM_GPS_MAP_OSD(osd);
     priv = self->priv;
@@ -548,7 +548,7 @@ osm_gps_map_osd_button_press (OsmGpsMapLayer *osd,
     OsmGpsMapOsdPrivate *priv;
     GtkAllocation allocation;
 
-    g_return_val_if_fail(OSM_IS_GPS_MAP_OSD(osd), FALSE);
+    g_return_val_if_fail(OSM_GPS_MAP_IS_OSD(osd), FALSE);
 
     self = OSM_GPS_MAP_OSD(osd);
     priv = self->priv;

--- a/src/osm-gps-map-osd.h
+++ b/src/osm-gps-map-osd.h
@@ -27,8 +27,8 @@ G_BEGIN_DECLS
 #define OSM_TYPE_GPS_MAP_OSD            (osm_gps_map_osd_get_type())
 #define OSM_GPS_MAP_OSD(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj),  OSM_TYPE_GPS_MAP_OSD, OsmGpsMapOsd))
 #define OSM_GPS_MAP_OSD_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass),   OSM_TYPE_GPS_MAP_OSD, OsmGpsMapOsdClass))
-#define OSM_IS_GPS_MAP_OSD(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj),  OSM_TYPE_GPS_MAP_OSD))
-#define OSM_IS_GPS_MAP_OSD_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass),   OSM_TYPE_GPS_MAP_OSD))
+#define OSM_GPS_MAP_IS_OSD(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj),  OSM_TYPE_GPS_MAP_OSD))
+#define OSM_GPS_MAP_IS_OSD_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass),   OSM_TYPE_GPS_MAP_OSD))
 #define OSM_GPS_MAP_OSD_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj),   OSM_TYPE_GPS_MAP_OSD, OsmGpsMapOsdClass))
 
 typedef struct _OsmGpsMapOsd        OsmGpsMapOsd;

--- a/src/osm-gps-map-polygon.c
+++ b/src/osm-gps-map-polygon.c
@@ -118,7 +118,7 @@ osm_gps_map_polygon_set_property (GObject      *object,
 static void
 osm_gps_map_polygon_dispose (GObject *object)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP_POLYGON (object));
+    g_return_if_fail (OSM_GPS_MAP_IS_POLYGON (object));
 	OsmGpsMapPolygon* poly = OSM_GPS_MAP_POLYGON(object);
 	g_object_unref(poly->priv->track);
 

--- a/src/osm-gps-map-polygon.h
+++ b/src/osm-gps-map-polygon.h
@@ -30,8 +30,8 @@ G_BEGIN_DECLS
 #define OSM_TYPE_GPS_MAP_POLYGON              osm_gps_map_polygon_get_type()
 #define OSM_GPS_MAP_POLYGON(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSM_TYPE_GPS_MAP_POLYGON, OsmGpsMapPolygon))
 #define OSM_GPS_MAP_POLYGON_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), OSM_TYPE_GPS_MAP_POLYGON, OsmGpsMapPolygonClass))
-#define OSM_IS_GPS_MAP_POLYGON(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_POLYGON))
-#define OSM_IS_GPS_MAP_POLYGON_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_POLYGON))
+#define OSM_GPS_MAP_IS_POLYGON(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_POLYGON))
+#define OSM_GPS_MAP_IS_POLYGON_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_POLYGON))
 #define OSM_GPS_MAP_POLYGON_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), OSM_TYPE_GPS_MAP_POLYGON, OsmGpsMapPolygonClass))
 
 typedef struct _OsmGpsMapPolygon OsmGpsMapPolygon;

--- a/src/osm-gps-map-track.c
+++ b/src/osm-gps-map-track.c
@@ -145,7 +145,7 @@ osm_gps_map_track_set_property (GObject      *object,
 static void
 osm_gps_map_track_dispose (GObject *object)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (object));
+    g_return_if_fail (OSM_GPS_MAP_IS_TRACK (object));
     OsmGpsMapTrackPrivate *priv = OSM_GPS_MAP_TRACK(object)->priv;
 
     if (priv->track) {
@@ -292,7 +292,7 @@ osm_gps_map_track_init (OsmGpsMapTrack *self)
 void
 osm_gps_map_track_add_point (OsmGpsMapTrack *track, const OsmGpsMapPoint *point)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    g_return_if_fail (OSM_GPS_MAP_IS_TRACK (track));
     OsmGpsMapTrackPrivate *priv = track->priv;
 
     OsmGpsMapPoint *p = g_boxed_copy (OSM_TYPE_GPS_MAP_POINT, point);
@@ -331,14 +331,14 @@ OsmGpsMapPoint* osm_gps_map_track_get_point(OsmGpsMapTrack* track, int pos)
 GSList *
 osm_gps_map_track_get_points (OsmGpsMapTrack *track)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP_TRACK (track), NULL);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_TRACK (track), NULL);
     return track->priv->track;
 }
 
 void                
 osm_gps_map_track_set_color (OsmGpsMapTrack *track, GdkRGBA *color)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    g_return_if_fail (OSM_GPS_MAP_IS_TRACK (track));
     track->priv->color.red = color->red;
     track->priv->color.green = color->green;
     track->priv->color.blue = color->blue;
@@ -347,7 +347,7 @@ osm_gps_map_track_set_color (OsmGpsMapTrack *track, GdkRGBA *color)
 void
 osm_gps_map_track_get_color (OsmGpsMapTrack *track, GdkRGBA *color)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP_TRACK (track));
+    g_return_if_fail (OSM_GPS_MAP_IS_TRACK (track));
     color->red = track->priv->color.red;
     color->green = track->priv->color.green;
     color->blue = track->priv->color.blue;

--- a/src/osm-gps-map-track.h
+++ b/src/osm-gps-map-track.h
@@ -31,8 +31,8 @@ G_BEGIN_DECLS
 #define OSM_TYPE_GPS_MAP_TRACK              osm_gps_map_track_get_type()
 #define OSM_GPS_MAP_TRACK(obj)              (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSM_TYPE_GPS_MAP_TRACK, OsmGpsMapTrack))
 #define OSM_GPS_MAP_TRACK_CLASS(klass)      (G_TYPE_CHECK_CLASS_CAST ((klass), OSM_TYPE_GPS_MAP_TRACK, OsmGpsMapTrackClass))
-#define OSM_IS_GPS_MAP_TRACK(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_TRACK))
-#define OSM_IS_GPS_MAP_TRACK_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_TRACK))
+#define OSM_GPS_MAP_IS_TRACK(obj)           (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP_TRACK))
+#define OSM_GPS_MAP_IS_TRACK_CLASS(klass)   (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP_TRACK))
 #define OSM_GPS_MAP_TRACK_GET_CLASS(obj)    (G_TYPE_INSTANCE_GET_CLASS ((obj), OSM_TYPE_GPS_MAP_TRACK, OsmGpsMapTrackClass))
 
 typedef struct _OsmGpsMapTrack OsmGpsMapTrack;

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -1520,7 +1520,7 @@ maybe_autocenter_map (OsmGpsMap *map)
     OsmGpsMapPrivate *priv;
     GtkAllocation allocation;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
     gtk_widget_get_allocation(GTK_WIDGET(map), &allocation);
 
@@ -1875,7 +1875,7 @@ osm_gps_map_finalize (GObject *object)
 static void
 osm_gps_map_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (object));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (object));
     OsmGpsMap *map = OSM_GPS_MAP(object);
     OsmGpsMapPrivate *priv = map->priv;
 
@@ -2021,7 +2021,7 @@ osm_gps_map_set_property (GObject *object, guint prop_id, const GValue *value, G
 static void
 osm_gps_map_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (object));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (object));
     OsmGpsMap *map = OSM_GPS_MAP(object);
     OsmGpsMapPrivate *priv = map->priv;
 
@@ -3036,7 +3036,7 @@ osm_gps_map_set_center (OsmGpsMap *map, float latitude, float longitude)
     OsmGpsMapPrivate *priv;
     GtkAllocation allocation;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
 
     priv = map->priv;
     gtk_widget_get_allocation(GTK_WIDGET(map), &allocation);
@@ -3065,7 +3065,7 @@ osm_gps_map_set_zoom_offset (OsmGpsMap *map, int zoom_offset)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP(map));
     priv = map->priv;
 
     if (zoom_offset != priv->tile_zoom_offset)
@@ -3086,7 +3086,7 @@ osm_gps_map_set_zoom (OsmGpsMap *map, int zoom)
     OsmGpsMapPrivate *priv;
     GtkAllocation allocation;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), 0);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), 0);
     priv = map->priv;
 
     if (zoom != priv->map_zoom)
@@ -3115,7 +3115,7 @@ osm_gps_map_set_zoom (OsmGpsMap *map, int zoom)
 int
 osm_gps_map_zoom_in (OsmGpsMap *map)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), 0);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), 0);
     return osm_gps_map_set_zoom(map, map->priv->map_zoom+1);
 }
 
@@ -3126,7 +3126,7 @@ osm_gps_map_zoom_in (OsmGpsMap *map)
 int
 osm_gps_map_zoom_out (OsmGpsMap *map)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), 0);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), 0);
     return osm_gps_map_set_zoom(map, map->priv->map_zoom-1);
 }
 
@@ -3139,7 +3139,7 @@ osm_gps_map_zoom_out (OsmGpsMap *map)
  * See the properties description for more information about construction
  * parameters than could be passed to g_object_new()
  *
- * Returns: a newly created #OsmGpsMap object.
+ * Returns: (transfer full): a newly created #OsmGpsMap object.
  **/
 GtkWidget *
 osm_gps_map_new (void)
@@ -3161,7 +3161,7 @@ osm_gps_map_scroll (OsmGpsMap *map, gint dx, gint dy)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
 
     priv->map_x += dx;
@@ -3183,7 +3183,7 @@ osm_gps_map_get_scale (OsmGpsMap *map)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), OSM_GPS_MAP_INVALID);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), OSM_GPS_MAP_INVALID);
     priv = map->priv;
 
     return osm_gps_map_get_scale_at_point(priv->map_zoom, priv->center_rlat, priv->center_rlon);
@@ -3221,7 +3221,7 @@ osm_gps_map_get_default_cache_directory (void)
 void
 osm_gps_map_set_keyboard_shortcut (OsmGpsMap *map, OsmGpsMapKey_t key, guint keyval)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     g_return_if_fail(key < OSM_GPS_MAP_KEY_MAX);
 
     map->priv->keybindings[key] = keyval;
@@ -3238,7 +3238,7 @@ osm_gps_map_track_add (OsmGpsMap *map, OsmGpsMapTrack *track)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
 
     g_object_ref(track);
@@ -3259,7 +3259,7 @@ osm_gps_map_track_add (OsmGpsMap *map, OsmGpsMapTrack *track)
 void
 osm_gps_map_track_remove_all (OsmGpsMap *map)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
 
     gslist_of_gobjects_free(&map->priv->tracks);
     osm_gps_map_map_redraw_idle(map);
@@ -3275,7 +3275,7 @@ osm_gps_map_track_remove (OsmGpsMap *map, OsmGpsMapTrack *track)
 {
     GSList *data;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), FALSE);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), FALSE);
     g_return_val_if_fail (track != NULL, FALSE);
 
     data = gslist_remove_one_gobject (&map->priv->tracks, G_OBJECT(track));
@@ -3288,7 +3288,7 @@ osm_gps_map_polygon_add (OsmGpsMap *map, OsmGpsMapPolygon *poly)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
 
     g_object_ref(poly);
@@ -3306,7 +3306,7 @@ osm_gps_map_polygon_add (OsmGpsMap *map, OsmGpsMapPolygon *poly)
 void
 osm_gps_map_polygon_remove_all(OsmGpsMap *map)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
 
     gslist_of_gobjects_free(&map->priv->polygons);
     osm_gps_map_map_redraw_idle(map);
@@ -3317,7 +3317,7 @@ osm_gps_map_polygon_remove(OsmGpsMap *map, OsmGpsMapPolygon *poly)
 {
     GSList *data;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), FALSE);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), FALSE);
     g_return_val_if_fail (poly != NULL, FALSE);
 
     data = gslist_remove_one_gobject (&map->priv->polygons, G_OBJECT(poly));
@@ -3336,7 +3336,7 @@ osm_gps_map_gps_clear (OsmGpsMap *map)
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
 
     g_object_unref(priv->gps_track);
@@ -3359,7 +3359,7 @@ osm_gps_map_gps_clear (OsmGpsMap *map)
 OsmGpsMapTrack *
 osm_gps_map_gps_get_track (OsmGpsMap *map)
 {
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), NULL);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), NULL);
     return map->priv->gps_track;
 }
 
@@ -3376,7 +3376,7 @@ osm_gps_map_gps_add (OsmGpsMap *map, float latitude, float longitude, float head
 {
     OsmGpsMapPrivate *priv;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     priv = map->priv;
 
     /* update the current point */
@@ -3460,7 +3460,7 @@ osm_gps_map_image_add_with_alignment_z (OsmGpsMap *map, float latitude, float lo
     OsmGpsMapImage *im;
     OsmGpsMapPoint pt;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), NULL);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), NULL);
     pt.rlat = deg2rad(latitude);
     pt.rlon = deg2rad(longitude);
 
@@ -3486,7 +3486,7 @@ osm_gps_map_image_remove (OsmGpsMap *map, OsmGpsMapImage *image)
 {
     GSList *data;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), FALSE);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), FALSE);
     g_return_val_if_fail (image != NULL, FALSE);
 
     data = gslist_remove_one_gobject (&map->priv->images, G_OBJECT(image));
@@ -3502,7 +3502,7 @@ osm_gps_map_image_remove (OsmGpsMap *map, OsmGpsMapImage *image)
 void
 osm_gps_map_image_remove_all (OsmGpsMap *map)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
 
     gslist_of_gobjects_free(&map->priv->images);
     osm_gps_map_map_redraw_idle(map);
@@ -3517,7 +3517,7 @@ osm_gps_map_image_remove_all (OsmGpsMap *map)
 void
 osm_gps_map_layer_add (OsmGpsMap *map, OsmGpsMapLayer *layer)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     g_return_if_fail (OSM_GPS_MAP_IS_LAYER (layer));
 
     g_object_ref(G_OBJECT(layer));
@@ -3535,7 +3535,7 @@ osm_gps_map_layer_remove (OsmGpsMap *map, OsmGpsMapLayer *layer)
 {
     GSList *data;
 
-    g_return_val_if_fail (OSM_IS_GPS_MAP (map), FALSE);
+    g_return_val_if_fail (OSM_GPS_MAP_IS_MAP (map), FALSE);
     g_return_val_if_fail (layer != NULL, FALSE);
 
     data = gslist_remove_one_gobject (&map->priv->layers, G_OBJECT(layer));
@@ -3551,7 +3551,7 @@ osm_gps_map_layer_remove (OsmGpsMap *map, OsmGpsMapLayer *layer)
 void
 osm_gps_map_layer_remove_all (OsmGpsMap *map)
 {
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
 
     gslist_of_gobjects_free(&map->priv->layers);
     osm_gps_map_map_redraw_idle(map);
@@ -3575,7 +3575,7 @@ osm_gps_map_convert_screen_to_geographic(OsmGpsMap *map, gint pixel_x, gint pixe
     OsmGpsMapPrivate *priv;
     int map_x0, map_y0;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     g_return_if_fail (pt);
 
     priv = map->priv;
@@ -3604,7 +3604,7 @@ osm_gps_map_convert_geographic_to_screen(OsmGpsMap *map, OsmGpsMapPoint *pt, gin
     OsmGpsMapPrivate *priv;
     int map_x0, map_y0;
 
-    g_return_if_fail (OSM_IS_GPS_MAP (map));
+    g_return_if_fail (OSM_GPS_MAP_IS_MAP (map));
     g_return_if_fail (pt);
 
     priv = map->priv;

--- a/src/osm-gps-map-widget.h
+++ b/src/osm-gps-map-widget.h
@@ -33,8 +33,8 @@ G_BEGIN_DECLS
 #define OSM_TYPE_GPS_MAP             (osm_gps_map_get_type ())
 #define OSM_GPS_MAP(obj)             (G_TYPE_CHECK_INSTANCE_CAST ((obj), OSM_TYPE_GPS_MAP, OsmGpsMap))
 #define OSM_GPS_MAP_CLASS(klass)     (G_TYPE_CHECK_CLASS_CAST ((klass), OSM_TYPE_GPS_MAP, OsmGpsMapClass))
-#define OSM_IS_GPS_MAP(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP))
-#define OSM_IS_GPS_MAP_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP))
+#define OSM_GPS_MAP_IS_MAP(obj)          (G_TYPE_CHECK_INSTANCE_TYPE ((obj), OSM_TYPE_GPS_MAP))
+#define OSM_GPS_MAP_IS_MAP_CLASS(klass)  (G_TYPE_CHECK_CLASS_TYPE ((klass), OSM_TYPE_GPS_MAP))
 #define OSM_GPS_MAP_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), OSM_TYPE_GPS_MAP, OsmGpsMapClass))
 
 typedef struct _OsmGpsMapClass OsmGpsMapClass;


### PR DESCRIPTION
This fixes the warnings reported in #40 by renaming everything that started with `OSM_IS_GPS_MAP_X` to `OSM_GPS_MAP_IS_X`, so that it matches the OsmGpsMap prefix.
```
osm-gps-map-osd.h:30: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_OSD': Unknown namespace for symbol 'OSM_IS_GPS_MAP_OSD'
osm-gps-map-osd.h:31: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_OSD_CLASS': Unknown namespace for symbol 'OSM_IS_GPS_MAP_OSD_CLASS'
osm-gps-map-track.h:34: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_TRACK': Unknown namespace for symbol 'OSM_IS_GPS_MAP_TRACK'
osm-gps-map-track.h:35: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_TRACK_CLASS': Unknown namespace for symbol 'OSM_IS_GPS_MAP_TRACK_CLASS'
osm-gps-map-polygon.h:33: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_POLYGON': Unknown namespace for symbol 'OSM_IS_GPS_MAP_POLYGON'
osm-gps-map-polygon.h:34: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_POLYGON_CLASS': Unknown namespace for symbol 'OSM_IS_GPS_MAP_POLYGON_CLASS'
osm-gps-map-image.h:34: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_IMAGE': Unknown namespace for symbol 'OSM_IS_GPS_MAP_IMAGE'
osm-gps-map-image.h:35: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_IMAGE_CLASS': Unknown namespace for symbol 'OSM_IS_GPS_MAP_IMAGE_CLASS'
osm-gps-map-widget.h:36: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP': Unknown namespace for symbol 'OSM_IS_GPS_MAP'
osm-gps-map-widget.h:37: Warning: OsmGpsMap: symbol='OSM_IS_GPS_MAP_CLASS': Unknown namespace for symbol 'OSM_IS_GPS_MAP_CLASS'
```
The mapviewer C example and my python application work without modification, so it shouldn't effect the exposed interface. The mapviewer.py fails to show the map, but that seems be a different issue.