### PR TITLE
Remove gnome-common dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ docs/reference/libosmgpsmap.signals
 docs/reference/version.xml
 examples/editable_track
 examples/polygon
+m4/gnome-compiler-flags.m4
+m4/pkg.m4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 before_install:
 - sudo apt-get -qq update
-- sudo apt-get -qq install gnome-common gtk-doc-tools libglib2.0-dev libgtk-3-dev libsoup2.4-dev libgirepository1.0-dev
+- sudo apt-get -qq install gtk-doc-tools libglib2.0-dev libgtk-3-dev libsoup2.4-dev libgirepository1.0-dev
 before_script:
 - ./autogen.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
 - sudo apt-get -qq update
 - sudo apt-get -qq install gtk-doc-tools libglib2.0-dev libgtk-3-dev libsoup2.4-dev libgirepository1.0-dev
 before_script:
-- ./autogen.sh
+- ./autogen.sh --enable-gtk-doc
 script:
 - make

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,10 +13,6 @@ PKG_NAME="osm-gps-map"
     exit 1
 }
 
-which gnome-autogen.sh || {
-	echo "You need to install gnome-common from the GNOME SVN"
-	exit 1
-}
 
 REQUIRED_AUTOMAKE_VERSION=1.11 USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh --enable-gtk-doc "$@"
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,19 +1,41 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="osm-gps-map"
-#REQUIRED_M4MACROS=introspection.m4
+cd $srcdir
 
-(test -f $srcdir/configure.ac) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+        exit 1
 }
 
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-REQUIRED_AUTOMAKE_VERSION=1.11 USE_GNOME2_MACROS=1 USE_COMMON_DOC_BUILD=yes . gnome-autogen.sh --enable-gtk-doc "$@"
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
 
+aclocal --install || exit 1
+gtkdocize --copy || exit 1
 
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then
+                exit 0
+        else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi

--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -31,10 +31,6 @@ SCAN_OPTIONS=
 # e.g. MKDB_OPTIONS=--sgml-mode --output-format=xml
 MKDB_OPTIONS=--sgml-mode --output-format=xml --name-space=osm_gps_map_
 
-# Extra options to supply to gtkdoc-mktmpl
-# e.g. MKTMPL_OPTIONS=--only-section-tmpl
-MKTMPL_OPTIONS=
-
 # Extra options to supply to gtkdoc-fixref. Not normally needed.
 # e.g. FIXXREF_OPTIONS=--extra-dir=../gdk-pixbuf/html --extra-dir=../gdk/html
 FIXXREF_OPTIONS=

--- a/src/osm-gps-map-point.c
+++ b/src/osm-gps-map-point.c
@@ -63,6 +63,11 @@ osm_gps_map_point_new_radians(float rlat, float rlon)
     return p;
 }
 
+/**
+ * osm_gps_map_point_new_degrees_with_user_data:
+ *
+ * Since: 1.2.0
+ **/
 OsmGpsMapPoint *
 osm_gps_map_point_new_degrees_with_user_data(float lat, float lon, gpointer user_data)
 {
@@ -73,6 +78,11 @@ osm_gps_map_point_new_degrees_with_user_data(float lat, float lon, gpointer user
     return p;
 }
 
+/**
+ * osm_gps_map_point_new_radians_with_user_data:
+ *
+ * Since: 1.2.0
+ **/
 OsmGpsMapPoint *
 osm_gps_map_point_new_radians_with_user_data(float rlat, float rlon, gpointer user_data)
 {
@@ -120,12 +130,23 @@ osm_gps_map_point_set_radians(OsmGpsMapPoint *point, float rlat, float rlon)
     point->rlon = rlon;
 }
 
+/**
+ * osm_gps_map_point_get_user_data:
+ *
+ * Returns: (transfer none): The #OsmGpsMapPoint user data
+ * Since: 1.2.0
+ **/
 gpointer
 osm_gps_map_point_get_user_data(OsmGpsMapPoint *point)
 {
     return point->user_data;
 }
 
+/**
+ * osm_gps_map_point_set_user_data:
+ *
+ * Since: 1.2.0
+ **/
 void
 osm_gps_map_point_set_user_data(OsmGpsMapPoint *point, gpointer user_data)
 {


### PR DESCRIPTION
As reported in #59, `gnome-common` shouldn't be used any more. In `osm-gps-map` it was mainly used to generate the documentation with `gtk-doc-tools`. Building it with the `autogen.sh` example from the [migration guide](https://wiki.gnome.org/Projects/GnomeCommon/Migration) generates the HTML docs without issues.

This also includes a fix for the issue introduced in #34.