### PR TITLE
Fix for custom repo-uri

### DIFF
--- a/examples/mapviewer.py
+++ b/examples/mapviewer.py
@@ -218,7 +218,6 @@ from in the box below. Special metacharacters may be included in this url
                 self.osm = osmgpsmap.Map()
 
             self.vbox.pack_start(self.osm, True, True, 0)
-            self.osm.connect("button_release_event", self.map_clicked)
             self.osm.show()
 
     def print_tiles(self):

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -1051,7 +1051,7 @@ osm_gps_map_load_tile (OsmGpsMap *map, cairo_t *cr, int zoom, int x, int y, int 
 
     g_debug("Load actual tile %d,%d (%d,%d) z:%d", x, y, offset_x, offset_y, zoom);
 
-    if (priv->map_source == OSM_GPS_MAP_SOURCE_NULL) {
+    if (priv->map_source == OSM_GPS_MAP_SOURCE_NULL && priv->repo_uri == NULL) {
         osm_gps_map_blit_tile(map, priv->null_tile, cr, offset_x, offset_y,
                               priv->map_zoom, target_x, target_y);
         return;


### PR DESCRIPTION
A [kismon](https://github.com/Kismon/kismon) user reported that setting a custom tile URL doesn't work any more. I've traced the issue down to 05d9ea1ad15e5a06ecd1dd357120b8374855665d, where the default map_source value was changed from -1 to 0. Since then map_source is OSM_GPS_MAP_SOURCE_NULL when the map gets initialized with a custom repo-uri and loads `osm_gps_map_blit_tile` instead of the right tiles.

While testing it, I've noticed another issue in the `mapviewer.py`: Clicking on the on the `Load Map URI` button under the Map Repository URI option throws an error that says that `self.map_clicked` doesn't exist. The function was removed a long time ago and connecting the event is no longer necessary.

To reproduce the issue:
- Apply the change to the `mapviewer.py` and launch it
- Click the `Load Map URI` button and the map turns gray
- Close mapviewer.py, apply the changes to `osm-gps-map-widget.c` and rebuild it
- Click the `Load Map URI` button and the map remains.