### PR TITLE
pkg-config: fix requirement propagation

### DIFF
--- a/osmgpsmap-1.0.pc.in
+++ b/osmgpsmap-1.0.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: @PACKAGE_NAME@
 Description: Moving map widget using openstreet map data
 Version: @PACKAGE_VERSION@
-Requires: gtk+-3.0 libsoup-3.0
+Requires: gtk+-3.0
+Requires.private: libsoup-3.0
 Libs: -L${libdir} -losmgpsmap-1.0
 Cflags: -I${includedir}/osmgpsmap-1.0


### PR DESCRIPTION
public requires are intended for libraries that
are being included by public headers.
`libsoup` is only indluded in `widget.c`,
and thus does not need a public require.

Adding a public require makes dependents unable to properly include this.
Specifically, `cmake` (and potentially different tools)
will only pick up on `osm-gps-map` if all the dependencies it defines are there.
While it is possible to define libsoup in all dependents, this is unnecessary.

This has caused confusion downstream in nixpkgs [1] after removing libsoup from darktable.

[1] https://github.com/NixOS/nixpkgs/issues/402543
