### PR TITLE
Avoid div-by-zero in latlon2zoom when a latitude or longitude distance is zero

### DIFF
--- a/src/converter.c
+++ b/src/converter.c
@@ -22,6 +22,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <float.h>
+#include <limits.h>
 
 #include "private.h"
 #include "converter.h"
@@ -126,7 +127,14 @@ latlon2zoom(int pix_height,
 {
     float lat1_m = atanh(sin(lat1));
     float lat2_m = atanh(sin(lat2));
-    int zoom_lon = LOG2((double)(2 * pix_width * M_PI) / (TILESIZE * (lon2 - lon1)));
-    int zoom_lat = LOG2((double)(2 * pix_height * M_PI) / (TILESIZE * (lat2_m - lat1_m)));
+    float d_lon = lon2 - lon1;
+    float d_lat = lat2_m - lat1_m;
+    int zoom_lon = INT_MAX;
+    int zoom_lat = INT_MAX;
+
+    if (d_lon != 0.0f)
+        zoom_lon = LOG2((double)(2 * pix_width * M_PI) / (TILESIZE * d_lon));
+    if (d_lat != 0.0f)
+        zoom_lat = LOG2((double)(2 * pix_height * M_PI) / (TILESIZE * d_lat));
     return MIN(zoom_lon, zoom_lat);
 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -122,5 +122,11 @@ class TestOsmGpsMap(unittest.TestCase):
 		
 		self.osm.track_remove(track)
 
+	def test_zoom_fit_bbox_point(self):
+		# Degenerate bbox (one geotag). Must not crash; zoom clamps to max.
+		self.osm.zoom_fit_bbox(self.lat, self.lat, self.lon, self.lon)
+		self.assertEqual(self.osm.get_property('zoom'),
+				 self.osm.get_property('max-zoom'))
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Calling zoom_fit_bbox with equal latitudes and/or equal longitudes (one geotagged point, or a line) hit a divide-by-zero inside latlon2zoom.

Inspired by @DTJF in https://github.com/nzjrs/osm-gps-map/issues/101