### PR TITLE
Fix insert_point double free

### DIFF
--- a/src/osm-gps-map-track.c
+++ b/src/osm-gps-map-track.c
@@ -312,11 +312,16 @@ int osm_gps_map_track_n_points(OsmGpsMapTrack* track)
     return g_slist_length(track->priv->track);
 }
 
-void osm_gps_map_track_insert_point(OsmGpsMapTrack* track, OsmGpsMapPoint* np, int pos)
+void
+osm_gps_map_track_insert_point (OsmGpsMapTrack* track, OsmGpsMapPoint* np, int pos)
 {
-    OsmGpsMapTrackPrivate* priv = track->priv;
-    priv->track = g_slist_insert(priv->track, np, pos);
-    g_signal_emit(track, signals[POINT_INSERTED], 0, pos);
+    // TODO: const OsmGpsMapPoint * like add_point (1.3)
+    g_return_if_fail (OSM_GPS_MAP_IS_TRACK (track));
+    OsmGpsMapTrackPrivate *priv = track->priv;
+
+    OsmGpsMapPoint *p = g_boxed_copy (OSM_TYPE_GPS_MAP_POINT, np);
+    priv->track = g_slist_insert (priv->track, p, pos);
+    g_signal_emit (track, signals[POINT_INSERTED], 0, pos);
 }
 
 OsmGpsMapPoint* osm_gps_map_track_get_point(OsmGpsMapTrack* track, int pos)

--- a/src/osm-gps-map-widget.c
+++ b/src/osm-gps-map-widget.c
@@ -2242,9 +2242,9 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                         dist_sqrd = (event->x - ptx) * (event->x-ptx) + (event->y-pty) * (event->y-pty);
                         if(dist_sqrd <= ((DOT_RADIUS + 1) * (DOT_RADIUS + 1)))
                         {
-                            OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
-                            osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
-                            osm_gps_map_track_insert_point(track, newpoint, ctr);
+                            OsmGpsMapPoint newpoint;
+                            osm_gps_map_convert_screen_to_geographic(map, ptx, pty, &newpoint);
+                            osm_gps_map_track_insert_point(track, &newpoint, ctr);
                             osm_gps_map_map_redraw(map);
                             return FALSE;
                         }
@@ -2301,9 +2301,9 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                         dist_sqrd = (event->x - ptx) * (event->x-ptx) + (event->y-pty) * (event->y-pty);
                         if(dist_sqrd <= ((DOT_RADIUS + 1) * (DOT_RADIUS + 1)))
                         {
-                            OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
-                            osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
-                            osm_gps_map_track_insert_point(track, newpoint, ctr);
+                            OsmGpsMapPoint newpoint;
+                            osm_gps_map_convert_screen_to_geographic(map, ptx, pty, &newpoint);
+                            osm_gps_map_track_insert_point(track, &newpoint, ctr);
                             osm_gps_map_map_redraw(map);
                             return FALSE;
                         }
@@ -2324,9 +2324,9 @@ osm_gps_map_button_press (GtkWidget *widget, GdkEventButton *event)
                 float dist_sqrd = (event->x - ptx) * (event->x-ptx) + (event->y-pty) * (event->y-pty);
                 if(dist_sqrd <= ((DOT_RADIUS + 1) * (DOT_RADIUS + 1)))
                 {
-                    OsmGpsMapPoint* newpoint = malloc(sizeof(OsmGpsMapPoint));
-                    osm_gps_map_convert_screen_to_geographic(map, ptx, pty, newpoint);
-                    osm_gps_map_track_insert_point(track, newpoint, ctr);
+                    OsmGpsMapPoint newpoint;
+                    osm_gps_map_convert_screen_to_geographic(map, ptx, pty, &newpoint);
+                    osm_gps_map_track_insert_point(track, &newpoint, ctr);
                     osm_gps_map_map_redraw(map);
                     return FALSE;
                 }

--- a/tests/test.py
+++ b/tests/test.py
@@ -122,5 +122,12 @@ class TestOsmGpsMap(unittest.TestCase):
 		
 		self.osm.track_remove(track)
 
+	def test_insert_point(self):
+		# Issue #45: check insert_point does not double-free.
+		track = OsmGpsMap.MapTrack()
+		point = OsmGpsMap.MapPoint.new_degrees(self.lat, self.lon)
+		track.insert_point(point, 0)
+		self.assertEqual(track.n_points(), 1)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Using insert_point from Python works, but then the process exits with a double-free. Unlike add_point, it stored the caller's OsmGpsMapPoint instead of a copy, so the track and Python both free it.

Fixes #45