### PR TITLE
Update the project website for 1.2.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,19 +47,19 @@
 </head>
 
 <body>
-  <a href="http://github.com/nzjrs/osm-gps-map"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+  <a href="https://github.com/nzjrs/osm-gps-map"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 
   <div id="container">
 
     <div class="download">
-      <a href="http://github.com/nzjrs/osm-gps-map/zipball/master">
-        <img border="0" width="90" src="http://github.com/images/modules/download/zip.png"></a>
-      <a href="http://github.com/nzjrs/osm-gps-map/tarball/master">
-        <img border="0" width="90" src="http://github.com/images/modules/download/tar.png"></a>
+      <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">
+        <img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
+      <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">
+        <img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
     </div>
 
-    <h1><a href="http://github.com/nzjrs/osm-gps-map">osm-gps-map</a>
-      <span class="small">by <a href="http://github.com/nzjrs">nzjrs</a></small></h1>
+    <h1><a href="https://github.com/nzjrs/osm-gps-map">osm-gps-map</a>
+      <span class="small">by <a href="https://github.com/nzjrs">nzjrs</a></span></h1>
 
     <div class="description">
       A Gtk+ Widget for Displaying OpenStreetMap tiles.
@@ -71,6 +71,7 @@
     <p>Currently supports a number of different mapping sources<br/>
     <ul>
         <li>openstreetmap (default)</li>
+        <li>OpenTopoMap</li>
         <li>maps-for-free</li>
         <li>satellite maps from a number of proprietary providers</li>
     </ul></p>
@@ -82,9 +83,9 @@
         <li>Automatic centering on new GPS points</li>
         <li>Support for multiple other tracks of co-ordinate points</li>
         <li>Adjustable Zoom</li>
-        <li>Built in support for keyboard navgation</li>
-        <li>Includes a <a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/">comprehensive examples</a></li>
-        <li>Simple, <a href="http://github.com/nzjrs/osm-gps-map/blob/master/src/osm-gps-map-widget.h">flat API</a></li>
+        <li>Built in support for keyboard navigation</li>
+        <li>Includes a <a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/">comprehensive examples</a></li>
+        <li>Simple, <a href="https://github.com/nzjrs/osm-gps-map/blob/master/src/osm-gps-map-widget.h">flat API</a></li>
         <li>Support for showing additional display layers rendered on top of the map</li>
         <li>Optional on screen display (OSD)</li>
         <li>Proper map copyright attribution and user-agent usage to comply with various map requirements</li>
@@ -95,18 +96,18 @@
         <li><a href="docs/reference/html/index.html">API Documentation</a></li>
         <li>Code examples</li>
         <ul>
-            <li><a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.c">mapviewer.c</a></li>
-            <li><a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.py">mapviewer.py</a></li>
-            <li><a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.js">mapviewer.js</a> (JavaScript example using GObject Introspection)</li>
-            <li><a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/polygon.c">polygon.c</a> (small polygon-on-map drawing example)</li>
-            <li><a href="http://github.com/nzjrs/osm-gps-map/blob/master/examples/editable_track.c">editable_track.c</a> (small example of an editable track feature)</li>
+            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.c">mapviewer.c</a></li>
+            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.py">mapviewer.py</a></li>
+            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.js">mapviewer.js</a> (JavaScript example using GObject Introspection)</li>
+            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/polygon.c">polygon.c</a> (small polygon-on-map drawing example)</li>
+            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/editable_track.c">editable_track.c</a> (small example of an editable track feature)</li>
         </ul>
-        <li>Please e-mail the <a href="http://groups.google.com/group/osm-gps-map">mailing list</a> for all questions.</li>
+        <li>Please e-mail the <a href="https://groups.google.com/group/osm-gps-map">mailing list</a> for all questions.</li>
         <li>Report issues using <a href="https://github.com/nzjrs/osm-gps-map/issues">issue tracker</a></li>
     </ul></p>
 
     <h2>Install Instructions</h2>
-    <p>osm-gps-map should be packaged by your distibution. On Debian, Ubuntu or
+    <p>osm-gps-map should be packaged by your distribution. On Debian, Ubuntu or
     similar, you can install the GTK+ library and its Python bindings like this:
 <pre>sudo apt-get install libosmgpsmap-1.0-1 gir1.2-osmgpsmap-1.0</pre></p>
     <p>And if you want to build some application that depends on osm-gps-map,
@@ -117,7 +118,7 @@
     <h3>Installing From Source</h3>
     <p>To build from source on Linux you will need to install the following dependencies:
     <ul>
-        <li>libsoup-2.4</li>
+        <li>libsoup-3.0</li>
         <li>gtk+-3.0</li>
         <li>cairo</li>
         <li>gobject-introspection</li>
@@ -130,14 +131,15 @@
     <h2>Download</h2>
     <p>You may download any of the following archives
     <ul>
+      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1</a></li>
       <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.0">1.2.0</a></li>
         <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.1.0">1.1.0</a></li>
-        <li>unstable snapshot <a href="http://github.com/nzjrs/osm-gps-map/tarball/master">(tar)</a> <a href="http://github.com/nzjrs/osm-gps-map/zipball/master">(zip)</a></li>
+        <li>unstable snapshot <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">(tar)</a> <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">(zip)</a></li>
     </ul>
     </p>
-    <p>You can also clone the project with <a href="http://git-scm.com">Git</a>
+    <p>You can also clone the project with <a href="https://git-scm.com">Git</a>
       by running:
-      <pre>$ git clone git://github.com/nzjrs/osm-gps-map</pre>
+      <pre>$ git clone https://github.com/nzjrs/osm-gps-map.git</pre>
     </p>
 
     <h2>License</h2>
@@ -156,12 +158,12 @@
 
     <h2>Contact</h2>
     <p><ul>
-        <li>osm-gps-map <a href="http://groups.google.com/group/osm-gps-map">mailing list</a></li>
+        <li>osm-gps-map <a href="https://groups.google.com/group/osm-gps-map">mailing list</a></li>
         <li>osm-gps-map <a href="https://github.com/nzjrs/osm-gps-map/issues">issue tracker</a></li>
     </ul></p>
 
     <div class="footer">
-      get the source code on GitHub : <a href="http://github.com/nzjrs/osm-gps-map">nzjrs/osm-gps-map</a>
+      get the source code on GitHub : <a href="https://github.com/nzjrs/osm-gps-map">nzjrs/osm-gps-map</a>
     </div>
 
   </div>

--- a/index.html
+++ b/index.html
@@ -54,10 +54,11 @@
     <p><img src="screenshot.png" alt="osm-gps-map showing an OpenStreetMap track in Christchurch"/><br/><img src="screenshot-osd.png" alt="osm-gps-map with on-screen display over satellite imagery"/></p>
     <p>Currently supports a number of different mapping sources<br/>
     <ul>
-        <li>openstreetmap (default)</li>
+        <li>OpenStreetMap (default)</li>
         <li>OpenTopoMap</li>
-        <li>maps-for-free</li>
-        <li>satellite maps from a number of proprietary providers</li>
+        <li>OpenCycleMap</li>
+        <li>Maps-For-Free</li>
+        <li>Google Maps / Satellite and Bing Maps (Virtual Earth)</li>
     </ul></p>
     <p>It also has the following features<br/>
     <ul>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     <p>It also has the following features<br/>
     <ul>
         <li>Intelligent, flexible and customizable caching of maps, including the ability to request a specific area of the map to be cached ahead of time</li>
-        <li>Recording of points of interest on the map (and the ability to add arbitary pixmaps at those points</li>
+        <li>Recording of points of interest on the map (and the ability to add arbitrary pixmaps at those points)</li>
         <li>Automatically draws a GPS track (a line showing the history of past added points)</li>
         <li>Automatic centering on new GPS points</li>
         <li>Support for multiple other tracks of co-ordinate points</li>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1 notes</a>)</p>
 
     <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
-    Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ and Maemo applications.</p>
+    Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ applications.</p>
     <p><img src="screenshot.png" alt="osm-gps-map showing an OpenStreetMap track in Christchurch"/><br/><img src="screenshot-osd.png" alt="osm-gps-map with on-screen display over satellite imagery"/></p>
     <p>Currently supports a number of different mapping sources<br/>
     <ul>

--- a/index.html
+++ b/index.html
@@ -101,17 +101,11 @@
 <pre>sudo apt install libosmgpsmap-1.0-dev</pre>
 
     <h3>Installing From Source</h3>
-    <p>To build from source on Linux you will need to install the following dependencies:</p>
-    <ul>
-        <li>libsoup-3.0</li>
-        <li>gtk+-3.0</li>
-        <li>cairo</li>
-        <li>gobject-introspection</li>
-    </ul>
-
-    <p>Once the dependencies have been installed you can build osm-gps-map. On Linux perform the following:
-<pre>./autogen.sh; make; make install #C library</pre>
-    </p>
+    <p>To build from source on Debian or Ubuntu you will need:</p>
+<pre>sudo apt install build-essential autoconf automake libtool \
+  libgtk-3-dev libsoup-3.0-dev libgirepository1.0-dev</pre>
+    <p>Then:</p>
+<pre>./autogen.sh &amp;&amp; make &amp;&amp; sudo make install</pre>
 
     <h2>Download</h2>
     <p>You may download any of the following archives:</p>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 
     <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
     Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ and Maemo applications.</p>
-    <p><img src="screenshot.png"/><br/><img src="screenshot-osd.png"/></p>
+    <p><img src="screenshot.png" alt="osm-gps-map showing an OpenStreetMap track in Christchurch"/><br/><img src="screenshot-osd.png" alt="osm-gps-map with on-screen display over satellite imagery"/></p>
     <p>Currently supports a number of different mapping sources<br/>
     <ul>
         <li>openstreetmap (default)</li>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<title>osm-gps-map by nzjrs</title>
 
@@ -16,8 +17,10 @@
     }
     #container {
       margin: 0 auto;
-      width: 700px;
+      max-width: 700px;
+      padding: 0 16px;
     }
+    img { max-width: 100%; height: auto; }
 		h1 { font-size: 3.8em; color: #cccccc; margin-bottom: 3px; }
 		h1 .small { font-size: 0.4em; }
 		h1 a { text-decoration: none }
@@ -26,7 +29,7 @@
     a { color: #cccccc; }
     .description { font-size: 1.2em; margin-bottom: 30px; margin-top: 30px; font-style: italic;}
     .download { float: right; }
-		pre { background: #000; color: #fff; padding: 15px;}
+		pre { background: #000; color: #fff; padding: 15px; overflow-x: auto;}
     hr { border: 0; width: 80%; border-bottom: 1px solid #aaa}
     .footer { text-align:center; padding-top:30px; font-style: italic; }
 	</style>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
     h3 { text-align: center; color: #cccccc; }
     a { color: #cccccc; }
     .description { font-size: 1.2em; margin-bottom: 30px; margin-top: 30px; font-style: italic;}
-    .download { float: right; }
 		pre { background: #000; color: #fff; padding: 15px; overflow-x: auto;}
     hr { border: 0; width: 80%; border-bottom: 1px solid #aaa}
     .footer { text-align:center; padding-top:30px; font-style: italic; }
@@ -39,13 +38,6 @@
   <a href="https://github.com/nzjrs/osm-gps-map"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 
   <div id="container">
-
-    <div class="download">
-      <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">
-        <img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
-      <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">
-        <img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
-    </div>
 
     <h1><a href="https://github.com/nzjrs/osm-gps-map">osm-gps-map</a>
       <span class="small">by <a href="https://github.com/nzjrs">nzjrs</a></span></h1>

--- a/index.html
+++ b/index.html
@@ -30,20 +30,6 @@
     hr { border: 0; width: 80%; border-bottom: 1px solid #aaa}
     .footer { text-align:center; padding-top:30px; font-style: italic; }
 	</style>
-
-<script type="text/javascript">
-
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-3707626-5']);
-  _gaq.push(['_trackPageview']);
-
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-
-</script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
       A Gtk+ Widget for Displaying OpenStreetMap tiles.
     </div>
 
-    <p>Download <a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.2.1/osm-gps-map-1.2.1.tar.gz">osm-gps-map-1.2.1.tar.gz</a>
-    (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1 notes</a>)</p>
+    <p>Download <a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.2.1/osm-gps-map-1.2.1.tar.gz">1.2.1 archive</a>
+    (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">Release notes for 1.2.1</a>)</p>
 
     <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
     Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ applications.</p>
@@ -110,10 +110,10 @@
     <h2>Download</h2>
     <p>You may download any of the following archives:</p>
     <ul>
-      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1</a></li>
-      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.0">1.2.0</a></li>
-        <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.1.0">1.1.0</a></li>
-        <li>unstable snapshot <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">(tar)</a> <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">(zip)</a></li>
+      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.2.1/osm-gps-map-1.2.1.tar.gz">1.2.1 archive</a> (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">Release notes for 1.2.1</a>)</li>
+      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.2.0/osm-gps-map-1.2.0.tar.gz">1.2.0 archive</a> (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.0">Release notes for 1.2.0</a>)</li>
+      <li><a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.1.0/osm-gps-map-1.1.0.tar.gz">1.1.0 archive</a> (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.1.0">Release notes for 1.1.0</a>)</li>
+      <li>git snapshot of master <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">(tar)</a> <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">(zip)</a></li>
     </ul>
     <p>You can also clone the project with <a href="https://git-scm.com">Git</a>
       by running:

--- a/index.html
+++ b/index.html
@@ -97,9 +97,8 @@
     similar, you can install the GTK+ library and its Python bindings like this:
 <pre>sudo apt install libosmgpsmap-1.0-1 gir1.2-osmgpsmap-1.0 python3-gi</pre></p>
     <p>And if you want to build some application that depends on osm-gps-map,
-       you can install development binding like this:
-       <pre>sudo apt-get install libosmgpsmap-1.0-dev</pre>
-    </p>
+       you can install the development files like this:</p>
+<pre>sudo apt install libosmgpsmap-1.0-dev</pre>
 
     <h3>Installing From Source</h3>
     <p>To build from source on Linux you will need to install the following dependencies:</p>

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         <li>Support for multiple other tracks of co-ordinate points</li>
         <li>Adjustable Zoom</li>
         <li>Built in support for keyboard navigation</li>
-        <li>Includes a <a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/">comprehensive examples</a></li>
+        <li>Includes a <a href="https://github.com/nzjrs/osm-gps-map/tree/master/examples/">set of examples</a></li>
         <li>Simple, <a href="https://github.com/nzjrs/osm-gps-map/blob/master/src/osm-gps-map-widget.h">flat API</a></li>
         <li>Support for showing additional display layers rendered on top of the map</li>
         <li>Optional on screen display (OSD)</li>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 
-	<title>nzjrs/osm-gps-map @ GitHub</title>
+	<title>osm-gps-map by nzjrs</title>
 
 	<style type="text/css">
 		body {

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
       A Gtk+ Widget for Displaying OpenStreetMap tiles.
     </div>
 
+    <p>Download <a href="https://github.com/nzjrs/osm-gps-map/releases/download/1.2.1/osm-gps-map-1.2.1.tar.gz">osm-gps-map-1.2.1.tar.gz</a>
+    (<a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1 notes</a>)</p>
+
     <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
     Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ and Maemo applications.</p>
     <p><img src="screenshot.png"/><br/><img src="screenshot-osd.png"/></p>

--- a/index.html
+++ b/index.html
@@ -52,15 +52,15 @@
     <p>A Gtk+ widget (and Python bindings) that when given GPS co-ordinates, draws a GPS track, and points of interest on a moving map display.
     Downloads map data from a number of websites, including openstreetmap.org. The library has excellent performance and is currently used in a number of Gtk+ applications.</p>
     <p><img src="screenshot.png" alt="osm-gps-map showing an OpenStreetMap track in Christchurch"/><br/><img src="screenshot-osd.png" alt="osm-gps-map with on-screen display over satellite imagery"/></p>
-    <p>Currently supports a number of different mapping sources<br/>
+    <p>Currently supports a number of different mapping sources:</p>
     <ul>
         <li>OpenStreetMap (default)</li>
         <li>OpenTopoMap</li>
         <li>OpenCycleMap</li>
         <li>Maps-For-Free</li>
         <li>Google Maps / Satellite and Bing Maps (Virtual Earth)</li>
-    </ul></p>
-    <p>It also has the following features<br/>
+    </ul>
+    <p>It also has the following features:</p>
     <ul>
         <li>Intelligent, flexible and customizable caching of maps, including the ability to request a specific area of the map to be cached ahead of time</li>
         <li>Recording of points of interest on the map (and the ability to add arbitrary pixmaps at those points)</li>
@@ -77,19 +77,20 @@
     </ul>
 
     <h2>Documentation</h2>
-    <p><ul>
+    <ul>
         <li><a href="docs/reference/html/index.html">API Documentation</a></li>
-        <li>Code examples</li>
-        <ul>
-            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.c">mapviewer.c</a></li>
-            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.py">mapviewer.py</a></li>
-            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.js">mapviewer.js</a> (JavaScript example using GObject Introspection)</li>
-            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/polygon.c">polygon.c</a> (small polygon-on-map drawing example)</li>
-            <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/editable_track.c">editable_track.c</a> (small example of an editable track feature)</li>
-        </ul>
+        <li>Code examples
+            <ul>
+                <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.c">mapviewer.c</a></li>
+                <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.py">mapviewer.py</a></li>
+                <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/mapviewer.js">mapviewer.js</a> (JavaScript example using GObject Introspection)</li>
+                <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/polygon.c">polygon.c</a> (small polygon-on-map drawing example)</li>
+                <li><a href="https://github.com/nzjrs/osm-gps-map/blob/master/examples/editable_track.c">editable_track.c</a> (small example of an editable track feature)</li>
+            </ul>
+        </li>
         <li>Please e-mail the <a href="https://groups.google.com/group/osm-gps-map">mailing list</a> for all questions.</li>
         <li>Report issues using <a href="https://github.com/nzjrs/osm-gps-map/issues">issue tracker</a></li>
-    </ul></p>
+    </ul>
 
     <h2>Install Instructions</h2>
     <p>osm-gps-map should be packaged by your distribution. On Debian, Ubuntu or
@@ -101,51 +102,50 @@
     </p>
 
     <h3>Installing From Source</h3>
-    <p>To build from source on Linux you will need to install the following dependencies:
+    <p>To build from source on Linux you will need to install the following dependencies:</p>
     <ul>
         <li>libsoup-3.0</li>
         <li>gtk+-3.0</li>
         <li>cairo</li>
         <li>gobject-introspection</li>
-    </ul></p>
+    </ul>
 
     <p>Once the dependencies have been installed you can build osm-gps-map. On Linux perform the following:
 <pre>./autogen.sh; make; make install #C library</pre>
     </p>
 
     <h2>Download</h2>
-    <p>You may download any of the following archives
+    <p>You may download any of the following archives:</p>
     <ul>
       <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.1">1.2.1</a></li>
       <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.2.0">1.2.0</a></li>
         <li><a href="https://github.com/nzjrs/osm-gps-map/releases/tag/1.1.0">1.1.0</a></li>
         <li>unstable snapshot <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.tar.gz">(tar)</a> <a href="https://github.com/nzjrs/osm-gps-map/archive/refs/heads/master.zip">(zip)</a></li>
     </ul>
-    </p>
     <p>You can also clone the project with <a href="https://git-scm.com">Git</a>
       by running:
       <pre>$ git clone https://github.com/nzjrs/osm-gps-map.git</pre>
     </p>
 
     <h2>License</h2>
-    <p><ul>
+    <ul>
         <li>GPLv2+</li>
-    </ul></p>
+    </ul>
 
     <h2>Authors</h2>
-    <p><ul>
+    <ul>
         <li>John Stowers</li>
         <li>Till Harbaum</li>
         <li>Alberto Mardegan</li>
         <li>Mark Cottrell</li>
         <li>Originally based on tangoGPS by Marcus Bauer</li>
-    </ul></p>
+    </ul>
 
     <h2>Contact</h2>
-    <p><ul>
+    <ul>
         <li>osm-gps-map <a href="https://groups.google.com/group/osm-gps-map">mailing list</a></li>
         <li>osm-gps-map <a href="https://github.com/nzjrs/osm-gps-map/issues">issue tracker</a></li>
-    </ul></p>
+    </ul>
 
     <div class="footer">
       get the source code on GitHub : <a href="https://github.com/nzjrs/osm-gps-map">nzjrs/osm-gps-map</a>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
     <h2>Install Instructions</h2>
     <p>osm-gps-map should be packaged by your distribution. On Debian, Ubuntu or
     similar, you can install the GTK+ library and its Python bindings like this:
-<pre>sudo apt-get install libosmgpsmap-1.0-1 gir1.2-osmgpsmap-1.0</pre></p>
+<pre>sudo apt install libosmgpsmap-1.0-1 gir1.2-osmgpsmap-1.0 python3-gi</pre></p>
     <p>And if you want to build some application that depends on osm-gps-map,
        you can install development binding like this:
        <pre>sudo apt-get install libosmgpsmap-1.0-dev</pre>


### PR DESCRIPTION
The GitHub Pages site still listed 1.2.0 and libsoup-2.4, and the fork ribbon was a dead S3 URL. The release job only copies gtk-doc HTML, so the landing page never got a 1.2.1 pass.

Updated for 1.2.1:

- https on remaining links
- typos, dead links, Maemo, leftover 1.2.0 stuff
- dropped Google Analytics
- title is just "osm-gps-map by nzjrs"
- readable on a phone
- alt text on the screenshots
- 1.2.1 tarball at the top; Download lists archives + release notes

Preview: https://johnny-bit.github.io/osm-gps-map/