### PR TITLE
Add optional Glade catalog installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,8 @@
 
 SUBDIRS = src examples docs
 AM_DISTCHECK_CONFIGURE_FLAGS =                  \
-    --enable-gtk-doc
+    --enable-gtk-doc                            \
+    --enable-glade-catalog
 
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,11 +16,12 @@ doc_DATA =                                      \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = osmgpsmap-1.0.pc
 
-gladecatalogdir = $(datadir)/glade/catalogs
-dist_gladecatalog_DATA = osmgpsmap.xml
+if ENABLE_GLADE_CATALOG
+gladecatalog_DATA = osmgpsmap.xml
+endif
 
 # Unit tests ship in the tarball (CI/git also run them in-tree).
-EXTRA_DIST = tests/test.py
+EXTRA_DIST = tests/test.py osmgpsmap.xml
 
 DISTCLEANFILES = gtk-doc.make
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,7 @@ if ENABLE_GLADE_CATALOG
 gladecatalog_DATA = osmgpsmap.xml
 endif
 
-# Unit tests ship in the tarball (CI/git also run them in-tree).
+# tests/test.py and osmgpsmap.xml ship in the tarball even if not installed.
 EXTRA_DIST = tests/test.py osmgpsmap.xml
 
 DISTCLEANFILES = gtk-doc.make

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,9 @@ doc_DATA =                                      \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = osmgpsmap-1.0.pc
 
+gladecatalogdir = $(datadir)/glade/catalogs
+dist_gladecatalog_DATA = osmgpsmap.xml
+
 # Unit tests ship in the tarball (CI/git also run them in-tree).
 EXTRA_DIST = tests/test.py
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,10 @@ AC_ARG_WITH([glade-catalogdir],
                             [Glade catalog directory (default=DATADIR/glade/catalogs)])],
             [gladecatalogdir=$withval],
             [gladecatalogdir='${datadir}/glade/catalogs'])
+if test "${with_glade_catalogdir+set}" = set && \
+   test "x$enable_glade_catalog" != xyes; then
+  AC_MSG_ERROR([--with-glade-catalogdir requires --enable-glade-catalog])
+fi
 AC_SUBST([gladecatalogdir])
 
 AC_CHECK_FUNCS(gdk_event_get_scroll_deltas)
@@ -93,4 +97,8 @@ echo
 echo Prefix............... : $prefix
 echo Introspection support : ${found_introspection}
 echo gtk-doc documentation : ${enable_gtk_doc}
+echo Glade catalog........ : ${enable_glade_catalog}
+if test "x$enable_glade_catalog" = xyes; then
+  echo Glade catalog dir.... : ${gladecatalogdir}
+fi
 echo

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,10 @@ AC_ARG_ENABLE([glade-catalog],
                               [install the Glade catalog (default=no)])],
               [enable_glade_catalog=$enableval],
               [enable_glade_catalog=no])
+case "$enable_glade_catalog" in
+  yes|no) ;;
+  *) AC_MSG_ERROR([--enable-glade-catalog accepts only yes or no]) ;;
+esac
 AM_CONDITIONAL([ENABLE_GLADE_CATALOG],
                [test "x$enable_glade_catalog" = xyes])
 

--- a/configure.ac
+++ b/configure.ac
@@ -46,9 +46,15 @@ AC_ARG_WITH([glade-catalogdir],
                             [Glade catalog directory (default=DATADIR/glade/catalogs)])],
             [gladecatalogdir=$withval],
             [gladecatalogdir='${datadir}/glade/catalogs'])
-if test "${with_glade_catalogdir+set}" = set && \
-   test "x$enable_glade_catalog" != xyes; then
-  AC_MSG_ERROR([--with-glade-catalogdir requires --enable-glade-catalog])
+if test "${with_glade_catalogdir+set}" = set; then
+  case "$with_glade_catalogdir" in
+    yes|no|'')
+      AC_MSG_ERROR([--with-glade-catalogdir requires a directory path])
+      ;;
+  esac
+  if test "x$enable_glade_catalog" != xyes; then
+    AC_MSG_ERROR([--with-glade-catalogdir requires --enable-glade-catalog])
+  fi
 fi
 AC_SUBST([gladecatalogdir])
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,21 @@ PKG_CHECK_MODULES(SOUP30,   [libsoup-3.0])
 # libgthread-2.0.
 PKG_CHECK_MODULES(GTHREAD, [gthread-2.0])
 
+AC_ARG_ENABLE([glade-catalog],
+              [AS_HELP_STRING([--enable-glade-catalog],
+                              [install the Glade catalog (default=no)])],
+              [enable_glade_catalog=$enableval],
+              [enable_glade_catalog=no])
+AM_CONDITIONAL([ENABLE_GLADE_CATALOG],
+               [test "x$enable_glade_catalog" = xyes])
+
+AC_ARG_WITH([glade-catalogdir],
+            [AS_HELP_STRING([--with-glade-catalogdir=PATH],
+                            [Glade catalog directory (default=DATADIR/glade/catalogs)])],
+            [gladecatalogdir=$withval],
+            [gladecatalogdir='${datadir}/glade/catalogs'])
+AC_SUBST([gladecatalogdir])
+
 AC_CHECK_FUNCS(gdk_event_get_scroll_deltas)
 
 AC_MSG_CHECKING([for Win32])

--- a/osmgpsmap.xml
+++ b/osmgpsmap.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<glade-catalog name="osmgpsmap" library="osmgpsmap-1.0" depends="gtk+" book="osm-gps-map">
+<glade-catalog name="osmgpsmap" library="osmgpsmap-1.0" depends="gtk+" book="osm-gps-map" supports="gtkbuilder">
     <glade-widget-classes>
         <glade-widget-class name="OsmGpsMap" generic-name="map" title="Map">
             <signals>
-                <signal id="point-added" />
-                <signal id="key_press_event" />
-                <signal id="point-changed" />
+                <signal id="changed" />
             </signals>
         </glade-widget-class>
     </glade-widget-classes>


### PR DESCRIPTION
`glade-previewer` fails with "Invalid object type 'OsmGpsMap'" because the catalog lived in git as `catalog.xml` and was never shipped or installed.

The catalog now ships as `osmgpsmap.xml`. Install is off by default. `--enable-glade-catalog` puts it in `${datadir}/glade/catalogs`; `--with-glade-catalogdir=PATH` selects another location and requires `--enable-glade-catalog`.

The catalog lists `OsmGpsMap::changed` and drops track/widget signals that were wrongly declared on the map.

Fixes #87